### PR TITLE
Add groups of access rights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,11 @@ jobs:
     - name: Check schema format
       run: diff -u ./schema/landlockconfig.json <(jq < ./schema/landlockconfig.json)
 
-    - name: Check JSON
+    - name: Check JSON mini
       run: ./schema/check.sh examples/mini-write-tmp.json
+
+    - name: Check JSON verbose
+      run: ./schema/check.sh examples/verbose-write-tmp.json
 
   ubuntu_24_rust_msrv:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ https://github.com/opencontainers/runtime-spec/pull/1241#pullrequestreview-25958
 
 The configuration should ease conciseness (e.g., by handling arrays of paths).
 
-**TODO:**
 The configuration should handle groups of access rights per [Landlock ABI
 version](https://landlock.io/rust-landlock/landlock/enum.ABI.html).
 

--- a/examples/mini-write-tmp.json
+++ b/examples/mini-write-tmp.json
@@ -2,32 +2,14 @@
   "ruleset": [
     {
       "handledAccessFs": [
-        "execute",
-        "write_file",
-        "read_file",
-        "read_dir",
-        "remove_dir",
-        "remove_file",
-        "make_char",
-        "make_dir",
-        "make_reg",
-        "make_sock",
-        "make_fifo",
-        "make_block",
-        "make_sym",
-        "refer",
-        "truncate",
-        "ioctl_dev"
+        "v5.all"
       ]
     }
   ],
   "pathBeneath": [
     {
       "allowedAccess": [
-        "execute",
-        "read_file",
-        "read_dir",
-        "refer"
+        "v5.read_execute"
       ],
       "parentFd": [
         ".",
@@ -41,18 +23,7 @@
     },
     {
       "allowedAccess": [
-        "write_file",
-        "read_file",
-        "read_dir",
-        "remove_dir",
-        "remove_file",
-        "make_dir",
-        "make_reg",
-        "make_sock",
-        "make_fifo",
-        "make_sym",
-        "refer",
-        "truncate"
+        "v5.read_write"
       ],
       "parentFd": [
         "/tmp"

--- a/examples/verbose-write-tmp.json
+++ b/examples/verbose-write-tmp.json
@@ -1,0 +1,62 @@
+{
+  "ruleset": [
+    {
+      "handledAccessFs": [
+        "execute",
+        "write_file",
+        "read_file",
+        "read_dir",
+        "remove_dir",
+        "remove_file",
+        "make_char",
+        "make_dir",
+        "make_reg",
+        "make_sock",
+        "make_fifo",
+        "make_block",
+        "make_sym",
+        "refer",
+        "truncate",
+        "ioctl_dev"
+      ]
+    }
+  ],
+  "pathBeneath": [
+    {
+      "allowedAccess": [
+        "execute",
+        "read_file",
+        "read_dir",
+        "refer"
+      ],
+      "parentFd": [
+        ".",
+        "/bin",
+        "/lib",
+        "/usr",
+        "/dev",
+        "/etc",
+        "/proc"
+      ]
+    },
+    {
+      "allowedAccess": [
+        "write_file",
+        "read_file",
+        "read_dir",
+        "remove_dir",
+        "remove_file",
+        "make_dir",
+        "make_reg",
+        "make_sock",
+        "make_fifo",
+        "make_sym",
+        "refer",
+        "truncate"
+      ],
+      "parentFd": [
+        "/tmp"
+      ]
+    }
+  ]
+}

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -54,9 +54,27 @@
             "make_fifo",
             "make_block",
             "make_sym",
+            "v1.all",
+            "v1.read_execute",
+            "v1.read_write",
             "refer",
+            "v2.all",
+            "v2.read_execute",
+            "v2.read_write",
             "truncate",
-            "ioctl_dev"
+            "v3.all",
+            "v3.read_execute",
+            "v3.read_write",
+            "v4.all",
+            "v4.read_execute",
+            "v4.read_write",
+            "ioctl_dev",
+            "v5.all",
+            "v5.read_execute",
+            "v5.read_write",
+            "v6.all",
+            "v6.read_execute",
+            "v6.read_write"
           ]
         }
       ]
@@ -70,7 +88,10 @@
           "type": "string",
           "enum": [
             "bind_tcp",
-            "connect_tcp"
+            "connect_tcp",
+            "v4.all",
+            "v5.all",
+            "v6.all"
           ]
         }
       ]

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -52,9 +52,24 @@ fn test_all_handled_access_fs() {
                         "make_fifo",
                         "make_block",
                         "make_sym",
+                        "v1.all",
+                        "v1.read_execute",
+                        "v1.read_write",
                         "refer",
+                        "v2.all",
+                        "v2.read_execute",
+                        "v2.read_write",
                         "truncate",
-                        "ioctl_dev"
+                        "v3.all",
+                        "v3.read_execute",
+                        "v3.read_write",
+                        "v4.all",
+                        "v4.read_execute",
+                        "v4.read_write",
+                        "ioctl_dev",
+                        "v5.all",
+                        "v5.read_execute",
+                        "v5.read_write"
                         ]
                 }
             ]
@@ -336,7 +351,9 @@ fn test_all_handled_access_net() {
                 {
                     "handledAccessNet": [
                         "bind_tcp",
-                        "connect_tcp"
+                        "connect_tcp",
+                        "v4.all",
+                        "v5.all"
                         ]
                 }
             ]


### PR DESCRIPTION
Add groups for the filesystem and the network access rights.

The filesystem gets (from v1 to v5):
- vX.all
- vX.read_execute
- vX.read_write

The network gets (from v4 to v5):
- vX.all

Groups are only defined starting with an ABI version that supports a class of access rights.