### PR TITLE
Remove support for file descriptor in the configuration

### DIFF
--- a/examples/mini-write-tmp.json
+++ b/examples/mini-write-tmp.json
@@ -16,7 +16,7 @@
       "allowedAccess": [
         "v5.read_execute"
       ],
-      "parentFd": [
+      "parent": [
         ".",
         "/bin",
         "/lib",
@@ -30,7 +30,7 @@
       "allowedAccess": [
         "v5.read_write"
       ],
-      "parentFd": [
+      "parent": [
         "/tmp"
       ]
     }

--- a/examples/mini-write-tmp.toml
+++ b/examples/mini-write-tmp.toml
@@ -7,12 +7,12 @@ handled_access_net = ["bind_tcp"]
 # Main system directories can be read.
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
-parent_fd = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]
+parent = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]
 
 # Only allow writing to /tmp.
 [[path_beneath]]
 allowed_access = ["v5.read_write"]
-parent_fd = ["/tmp"]
+parent = ["/tmp"]
 
 # Only web ports are allowed.
 [[net_port]]

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -56,7 +56,7 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let ruleset = build_ruleset(&config, None)?;
+    let ruleset = build_ruleset(&config)?;
     let status = restrict_self(ruleset, None)?;
     if status.ruleset == RulesetStatus::NotEnforced {
         bail!("Landlock is not supported by the running kernel.");

--- a/examples/verbose-write-tmp.json
+++ b/examples/verbose-write-tmp.json
@@ -29,7 +29,7 @@
         "read_dir",
         "refer"
       ],
-      "parentFd": [
+      "parent": [
         ".",
         "/bin",
         "/lib",
@@ -54,7 +54,7 @@
         "refer",
         "truncate"
       ],
-      "parentFd": [
+      "parent": [
         "/tmp"
       ]
     }

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -8,18 +8,6 @@
       "minimum": 0,
       "maximum": 18446744073709551615
     },
-    "file": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 2147483647
-        }
-      ]
-    },
     "accessFs": {
       "type": "string",
       "enum": [
@@ -114,16 +102,16 @@
               "$ref": "#/definitions/accessFs"
             }
           },
-          "parentFd": {
+          "parent": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/file"
+              "type": "string"
             }
           }
         },
         "required": [
           "allowedAccess",
-          "parentFd"
+          "parent"
         ],
         "additionalProperties": false
       }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -238,7 +238,7 @@ fn test_one_path_beneath_str() {
             "pathBeneath": [
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ "." ]
+                    "parent": [ "." ]
                 }
             ]
         }"#,
@@ -258,31 +258,11 @@ fn test_one_path_beneath_int() {
             "pathBeneath": [
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ 2 ]
+                    "parent": [ 2 ]
                 }
             ]
         }"#,
-        Ok(()),
-    );
-}
-
-#[test]
-fn test_mixed_path_beneath() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parentFd": [ ".", 2 ]
-                }
-            ]
-        }"#,
-        Ok(()),
+        Err(Category::Data),
     );
 }
 
@@ -298,7 +278,7 @@ fn test_dup_path_beneath_1() {
             "pathBeneath": [
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ ".", "." ]
+                    "parent": [ ".", "." ]
                 }
             ]
         }"#,
@@ -318,11 +298,11 @@ fn test_dup_path_beneath_2() {
             "pathBeneath": [
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ "." ]
+                    "parent": [ "." ]
                 },
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ "." ]
+                    "parent": [ "." ]
                 }
             ]
         }"#,
@@ -345,11 +325,11 @@ fn test_overlap_path_beneath() {
             "pathBeneath": [
                 {
                     "allowedAccess": [ "execute" ],
-                    "parentFd": [ "." ]
+                    "parent": [ "." ]
                 },
                 {
                     "allowedAccess": [ "execute", "read_file" ],
-                    "parentFd": [ "." ]
+                    "parent": [ "." ]
                 }
             ]
         }"#,


### PR DESCRIPTION
File descriptor are always relative to the caller, so it does not make a lot of sense to specify them in a configuration file.  Additionally, there is a good chance for these file descriptors to be misused or just not used at all.  If we need to rely on file descriptors, we should use a Landlock library.

Rename the "parentFd" field to "parent" because it would not make sense to keep the "Fd" part.  Only accept file paths in this "parent" field.

Simplify the build_ruleset() signature.

This is a breaking change.