### PR TITLE
Refactor Config type and improve tests

### DIFF
--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -39,9 +39,9 @@ fn main() -> anyhow::Result<()> {
     let config = match arg_config {
         ArgConfig::Json(name) => {
             if name == "-" {
-                Config::try_from_json(std::io::stdin())?
+                Config::parse_json(std::io::stdin())?
             } else {
-                Config::try_from_json(File::open(name).context("Failed to open JSON file")?)?
+                Config::parse_json(File::open(name).context("Failed to open JSON file")?)?
             }
         }
         ArgConfig::Toml(name) => {
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
             } else {
                 std::fs::read_to_string(name).context("Failed to open TOML file")?
             };
-            Config::try_from_toml(data.as_str())?
+            Config::parse_toml(data.as_str())?
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,7 @@ impl Config {
         Ok(ruleset_created)
     }
 
-    pub fn try_from_json<R>(reader: R) -> Result<Self, serde_json::Error>
+    pub fn parse_json<R>(reader: R) -> Result<Self, serde_json::Error>
     where
         R: std::io::Read,
     {
@@ -464,7 +464,7 @@ impl Config {
     }
 
     #[cfg(feature = "toml")]
-    pub fn try_from_toml(data: &str) -> Result<Self, toml::de::Error> {
+    pub fn parse_toml(data: &str) -> Result<Self, toml::de::Error> {
         // The TOML parser does not handle Read implementations,
         // see https://github.com/toml-rs/toml/issues/326
         let json: JsonConfig = toml::from_str::<TomlConfig>(data)?.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ use thiserror::Error;
 
 pub use landlock::{RestrictionStatus, RulesetStatus};
 
+#[cfg(test)]
+mod tests_parser;
+
 #[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 enum JsonFsAccessItem {

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,4 +1,4 @@
-use crate::Config;
+use crate::*;
 use serde_json::error::Category;
 
 fn assert_json(data: &str, ret: Result<(), Category>) {
@@ -7,6 +7,15 @@ fn assert_json(data: &str, ret: Result<(), Category>) {
         .map(|_| ())
         .map_err(|e| e.classify());
     assert_eq!(parsing_ret, ret);
+}
+
+fn parse_json(json: &str) -> Result<Config, Category> {
+    let cursor = std::io::Cursor::new(json);
+    Config::parse_json(cursor).map_err(|e| e.classify())
+}
+
+fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
+    Config::parse_toml(toml)
 }
 
 const LATEST_VERSION: u32 = 5;
@@ -40,77 +49,83 @@ fn assert_versions(name: &str, first_known_version: u32) {
 // FIXME: Such an empty ruleset doesn't make sense and should not be allowed.
 #[test]
 fn test_empty_ruleset() {
-    assert_json(
-        r#"{
-            "ruleset": []
-        }"#,
-        Ok(()),
-    );
+    let json = r#"{
+        "ruleset": []
+    }"#;
+    assert_eq!(parse_json(json), Ok(Default::default()),);
 }
 
 #[test]
 fn test_one_handled_access_fs() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_all_handled_access_fs_json() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [
-                        "execute",
-                        "write_file",
-                        "read_file",
-                        "read_dir",
-                        "remove_dir",
-                        "remove_file",
-                        "make_char",
-                        "make_dir",
-                        "make_reg",
-                        "make_sock",
-                        "make_fifo",
-                        "make_block",
-                        "make_sym",
-                        "v1.all",
-                        "v1.read_execute",
-                        "v1.read_write",
-                        "refer",
-                        "v2.all",
-                        "v2.read_execute",
-                        "v2.read_write",
-                        "truncate",
-                        "v3.all",
-                        "v3.read_execute",
-                        "v3.read_write",
-                        "v4.all",
-                        "v4.read_execute",
-                        "v4.read_write",
-                        "ioctl_dev",
-                        "v5.all",
-                        "v5.read_execute",
-                        "v5.read_write"
-                        ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [
+                    "execute",
+                    "write_file",
+                    "read_file",
+                    "read_dir",
+                    "remove_dir",
+                    "remove_file",
+                    "make_char",
+                    "make_dir",
+                    "make_reg",
+                    "make_sock",
+                    "make_fifo",
+                    "make_block",
+                    "make_sym",
+                    "v1.all",
+                    "v1.read_execute",
+                    "v1.read_write",
+                    "refer",
+                    "v2.all",
+                    "v2.read_execute",
+                    "v2.read_write",
+                    "truncate",
+                    "v3.all",
+                    "v3.read_execute",
+                    "v3.read_write",
+                    "v4.all",
+                    "v4.read_execute",
+                    "v4.read_write",
+                    "ioctl_dev",
+                    "v5.all",
+                    "v5.read_execute",
+                    "v5.read_write"
+                    ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::from_all(ABI::V5),
+            ..Default::default()
+        })
     );
 }
 
 #[test]
 fn test_all_handled_access_fs_toml() {
-    let data = r#"
+    let toml = r#"
         [[ruleset]]
         handled_access_fs = [
             "execute",
@@ -146,7 +161,13 @@ fn test_all_handled_access_fs_toml() {
             "v5.read_write",
         ]
     "#;
-    assert_eq!(Config::parse_toml(data).map(|_| ()), Ok(()));
+    assert_eq!(
+        parse_toml(toml),
+        Ok(Config {
+            handled_fs: AccessFs::from_all(ABI::V5),
+            ..Default::default()
+        })
+    );
 }
 
 #[test]
@@ -156,219 +177,248 @@ fn test_versions_access_fs() {
 
 #[test]
 fn test_unknown_ruleset_field() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "foo": []
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "foo": []
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data),);
 }
 
 #[test]
 fn test_dup_handled_access_fs_1() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute", "execute" ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute", "execute" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_dup_handled_access_fs_2() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                },
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            },
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_unknown_handled_access_fs_1() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "foo" ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "foo" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 #[test]
 fn test_unknown_handled_access_fs_2() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "bind_tcp" ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "bind_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 #[test]
 fn test_one_path_beneath_str() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ "." ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "." ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_one_path_beneath_int() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ 2 ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ 2 ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 #[test]
 fn test_dup_path_beneath_1() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ ".", "." ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ ".", "." ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_dup_path_beneath_2() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ "." ]
-                },
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ "." ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "." ]
+            },
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "." ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_overlap_path_beneath() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                },
-                {
-                    "handledAccessFs": [ "read_file" ]
-                }
-            ],
-            "pathBeneath": [
-                {
-                    "allowedAccess": [ "execute" ],
-                    "parent": [ "." ]
-                },
-                {
-                    "allowedAccess": [ "execute", "read_file" ],
-                    "parent": [ "." ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            },
+            {
+                "handledAccessFs": [ "read_file" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "." ]
+            },
+            {
+                "allowedAccess": [ "execute", "read_file" ],
+                "parent": [ "." ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute | AccessFs::ReadFile)]
+                .into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_one_handled_access_net() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessNet": [ "bind_tcp" ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "bind_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::BindTcp.into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_all_handled_access_net() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessNet": [
-                        "bind_tcp",
-                        "connect_tcp",
-                        "v4.all",
-                        "v5.all"
-                        ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [
+                    "bind_tcp",
+                    "connect_tcp",
+                    "v4.all",
+                    "v5.all"
+                    ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::from_all(ABI::V5),
+            ..Default::default()
+        }),
     );
 }
 
@@ -379,84 +429,88 @@ fn test_versions_access_net() {
 
 #[test]
 fn test_unknown_handled_access_net_1() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessNet": [ "foo" ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "foo" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 #[test]
 fn test_unknown_handled_access_net_2() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessNet": [ "execute" ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "execute" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 #[test]
 fn test_one_net_port() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessNet": [ "bind_tcp" ]
-                }
-            ],
-            "netPort": [
-                {
-                    "allowedAccess": [ "bind_tcp" ],
-                    "port": [ 443 ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "bind_tcp" ]
+            }
+        ],
+        "netPort": [
+            {
+                "allowedAccess": [ "bind_tcp" ],
+                "port": [ 443 ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::BindTcp.into(),
+            rules_net_port: [(443, AccessNet::BindTcp.into())].into(),
+            ..Default::default()
+        }),
     );
 }
 
 #[test]
 fn test_inconsistent_handled_access() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ],
-                    "handledAccessNet": [ "bind_tcp" ]
-                }
-            ]
-        }"#,
-        Err(Category::Data),
-    );
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ],
+                "handledAccessNet": [ "bind_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
 
 // FIXME: This should be forbidden at the parser level.
 #[test]
 fn test_inconsistent_access_net() {
-    assert_json(
-        r#"{
-            "ruleset": [
-                {
-                    "handledAccessFs": [ "execute" ]
-                }
-            ],
-            "netPort": [
-                {
-                    "allowedAccess": [ "bind_tcp" ],
-                    "port": [ 443 ]
-                }
-            ]
-        }"#,
-        Ok(()),
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "netPort": [
+            {
+                "allowedAccess": [ "bind_tcp" ],
+                "port": [ 443 ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            rules_net_port: [(443, AccessNet::BindTcp.into())].into(),
+            ..Default::default()
+        }),
     );
 }

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,4 +1,4 @@
-use landlockconfig::Config;
+use crate::Config;
 use serde_json::error::Category;
 
 fn assert_json(data: &str, ret: Result<(), Category>) {

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -356,7 +356,7 @@ fn test_overlap_path_beneath() {
                 "handledAccessFs": [ "execute" ]
             },
             {
-                "handledAccessFs": [ "read_file" ]
+                "handledAccessFs": [ "read_file", "write_file" ]
             }
         ],
         "pathBeneath": [
@@ -365,7 +365,15 @@ fn test_overlap_path_beneath() {
                 "parent": [ "." ]
             },
             {
+                "allowedAccess": [ "write_file" ],
+                "parent": [ "." ]
+            },
+            {
                 "allowedAccess": [ "execute", "read_file" ],
+                "parent": [ "." ]
+            },
+            {
+                "allowedAccess": [ "execute" ],
                 "parent": [ "." ]
             }
         ]
@@ -373,9 +381,12 @@ fn test_overlap_path_beneath() {
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
-            rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute | AccessFs::ReadFile)]
-                .into(),
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile | AccessFs::WriteFile,
+            rules_path_beneath: [(
+                PathBuf::from("."),
+                AccessFs::Execute | AccessFs::ReadFile | AccessFs::WriteFile
+            )]
+            .into(),
             ..Default::default()
         }),
     );
@@ -505,6 +516,39 @@ fn test_one_net_port() {
         Ok(Config {
             handled_net: AccessNet::BindTcp.into(),
             rules_net_port: [(443, AccessNet::BindTcp.into())].into(),
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn test_overlap_net_port() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "bind_tcp", "connect_tcp" ]
+            }
+        ],
+        "netPort": [
+            {
+                "allowedAccess": [ "connect_tcp" ],
+                "port": [ 443 ]
+            },
+            {
+                "allowedAccess": [ "bind_tcp" ],
+                "port": [ 443 ]
+            },
+            {
+                "allowedAccess": [ "connect_tcp" ],
+                "port": [ 443 ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::BindTcp | AccessNet::ConnectTcp,
+            rules_net_port: [(443, AccessNet::BindTcp | AccessNet::ConnectTcp)].into(),
             ..Default::default()
         }),
     );

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -382,6 +382,40 @@ fn test_overlap_path_beneath() {
 }
 
 #[test]
+fn test_normalization_path_beneath() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ ".", "./", ".", "a/./b" ]
+            },
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ ".//", "a/////b", "c/../c" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [
+                (PathBuf::from("."), AccessFs::Execute.into()),
+                (PathBuf::from("a/b"), AccessFs::Execute.into()),
+                (PathBuf::from("c/../c"), AccessFs::Execute.into()),
+            ]
+            .into(),
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
 fn test_one_handled_access_net() {
     let json = r#"{
         "ruleset": [

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -3,7 +3,7 @@ use serde_json::error::Category;
 
 fn assert_json(data: &str, ret: Result<(), Category>) {
     let cursor = std::io::Cursor::new(data);
-    let parsing_ret = Config::try_from_json(cursor)
+    let parsing_ret = Config::parse_json(cursor)
         .map(|_| ())
         .map_err(|e| e.classify());
     assert_eq!(parsing_ret, ret);
@@ -146,7 +146,7 @@ fn test_all_handled_access_fs_toml() {
             "v5.read_write",
         ]
     "#;
-    assert_eq!(Config::try_from_toml(data).map(|_| ()), Ok(()));
+    assert_eq!(Config::parse_toml(data).map(|_| ()), Ok(()));
 }
 
 #[test]


### PR DESCRIPTION
The Config type does not need to rely on any parsing type, but instead it should properly handle configuration updates (e.g. new rules, union, composition), minimize Landlock system calls when building a ruleset, be deterministic, and provide idempotency guarantees.

Rename methods.

Improve and add tests.