### PR TITLE
Improve Landlock ABI version testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ clap = { version = "4.5.28", features = ["derive"] }
 [[example]]
 name = "sandboxer"
 required-features = ["toml"]
+
+[patch.crates-io]
+landlock = { git = "https://github.com/landlock-lsm/rust-landlock.git" }


### PR DESCRIPTION
TODO: Remove patch.crates-io

Fully test the result of all known ABIs.

This commit relies on this trait implementation: From<i32> for ABI

Depends on https://github.com/landlock-lsm/rust-landlock/pull/88