### PR TITLE
Prepare for ABI v6 (scope)

### DIFF
--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -208,14 +208,14 @@ fn test_dup_handled_access_fs_1() {
     let json = r#"{
         "ruleset": [
             {
-                "handledAccessFs": [ "execute", "execute" ]
+                "handledAccessFs": [ "execute", "write_file", "execute" ]
             }
         ]
     }"#;
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            handled_fs: AccessFs::Execute.into(),
+            handled_fs: AccessFs::Execute | AccessFs::WriteFile,
             ..Default::default()
         }),
     );
@@ -226,17 +226,20 @@ fn test_dup_handled_access_fs_2() {
     let json = r#"{
         "ruleset": [
             {
-                "handledAccessFs": [ "execute" ]
+                "handledAccessFs": [ "write_file" ]
             },
             {
                 "handledAccessFs": [ "execute" ]
+            },
+            {
+                "handledAccessFs": [ "write_file" ]
             }
         ]
     }"#;
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            handled_fs: AccessFs::Execute.into(),
+            handled_fs: AccessFs::Execute | AccessFs::WriteFile,
             ..Default::default()
         }),
     );
@@ -487,6 +490,48 @@ fn test_versions_access_net() {
     assert_versions(ABI::V4, |version| {
         vec![format!(r#""handledAccessNet": [ "v{version}.all" ]"#)]
     });
+}
+
+#[test]
+fn test_dup_handled_access_net_1() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "bind_tcp", "connect_tcp", "bind_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::BindTcp | AccessNet::ConnectTcp,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn test_dup_handled_access_net_2() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "connect_tcp" ]
+            },
+            {
+                "handledAccessNet": [ "bind_tcp" ]
+            },
+            {
+                "handledAccessNet": [ "connect_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_net: AccessNet::BindTcp | AccessNet::ConnectTcp,
+            ..Default::default()
+        }),
+    );
 }
 
 #[test]

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -3,6 +3,8 @@ use landlock::{Access, AccessFs, AccessNet, ABI};
 use serde_json::error::Category;
 use std::path::PathBuf;
 
+const LATEST_ABI: ABI = ABI::V5;
+
 fn assert_json(data: &str, ret: Result<(), Category>) {
     let cursor = std::io::Cursor::new(data);
     let parsing_ret = Config::parse_json(cursor)
@@ -20,11 +22,10 @@ fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
     Config::parse_toml(toml)
 }
 
-const LATEST_VERSION: u32 = 5;
-
-fn assert_versions(name: &str, first_known_version: u32) {
-    let known_versions = first_known_version..=LATEST_VERSION;
-    let next_version = LATEST_VERSION + 1;
+fn assert_versions(name: &str, first_known_version: ABI) {
+    let latest_version = LATEST_ABI as u32;
+    let known_versions = (first_known_version as u32)..=latest_version;
+    let next_version = latest_version + 1;
     for version in 0..=next_version {
         let expected = if known_versions.contains(&version) {
             Ok(())
@@ -119,7 +120,7 @@ fn test_all_handled_access_fs_json() {
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            handled_fs: AccessFs::from_all(ABI::V5),
+            handled_fs: AccessFs::from_all(LATEST_ABI),
             ..Default::default()
         })
     );
@@ -166,7 +167,7 @@ fn test_all_handled_access_fs_toml() {
     assert_eq!(
         parse_toml(toml),
         Ok(Config {
-            handled_fs: AccessFs::from_all(ABI::V5),
+            handled_fs: AccessFs::from_all(LATEST_ABI),
             ..Default::default()
         })
     );
@@ -174,7 +175,7 @@ fn test_all_handled_access_fs_toml() {
 
 #[test]
 fn test_versions_access_fs() {
-    assert_versions("handledAccessFs", 1);
+    assert_versions("handledAccessFs", ABI::V1);
 }
 
 #[test]
@@ -463,7 +464,7 @@ fn test_all_handled_access_net() {
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            handled_net: AccessNet::from_all(ABI::V5),
+            handled_net: AccessNet::from_all(LATEST_ABI),
             ..Default::default()
         }),
     );
@@ -471,7 +472,7 @@ fn test_all_handled_access_net() {
 
 #[test]
 fn test_versions_access_net() {
-    assert_versions("handledAccessNet", 4);
+    assert_versions("handledAccessNet", ABI::V4);
 }
 
 #[test]


### PR DESCRIPTION
Prepare support for Landlock ABI 6: https://github.com/landlock-lsm/rust-landlock/pull/98

Add a bunch of tests to consolidate existing ones and add new ones.