### PR TITLE
Fix handling of only one kind of access right

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
     - name: Run the sandboxer example with TOML
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --toml examples/mini-write-tmp.toml true
 
+    - name: Run the sandboxer example with FS-only restrictions
+      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/verbose-write-tmp.json true
+
   ubuntu_24_rust_stable:
     runs-on: ubuntu-24.04
     needs: commit_list

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,11 +83,15 @@ impl From<JsonConfig> for Config {
 // TODO: Add a merge method to compose with another Config.
 impl Config {
     pub fn build_ruleset(&self) -> Result<RulesetCreated, BuildRulesetError> {
-        let mut ruleset_created = Ruleset::default()
-            .handle_access(self.handled_fs)?
-            .handle_access(self.handled_net)?
-            .create()?;
-
+        let mut ruleset = Ruleset::default();
+        let ruleset_ref = &mut ruleset;
+        if !self.handled_fs.is_empty() {
+            ruleset_ref.handle_access(self.handled_fs)?;
+        }
+        if !self.handled_net.is_empty() {
+            ruleset_ref.handle_access(self.handled_net)?;
+        }
+        let mut ruleset_created = ruleset.create()?;
         let ruleset_created_ref = &mut ruleset_created;
 
         for (parent, allowed_access) in &self.rules_path_beneath {


### PR DESCRIPTION
Commit 34aa832a4c93 ("Refactor Config to be idempotent") changed the way a ruleset is populated, always making two calls to Ruleset::handled_access(), one for each kind of access right.

Because the Landlock crate (rightfully) checks that we are not trying to handle an empty set of access right, Config::build_ruleset() may return an error if not both a filesystem and a network access rights are handled.

Fix this issue by only calling Ruleset::handled_access() when it is required, which restores the possibility to request only one kind of access right.

Add a new CI test with verbose-write-tmp.json which only enforce filesystem restrictions.

Part of #27 