### PR TITLE
Add support for Landlock ABI 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
     - name: Check JSON verbose
       run: ./schema/check.sh examples/verbose-write-tmp.json
 
+    - name: Check JSON scoped
+      run: ./schema/check.sh examples/mini-scoped.json
+
   ubuntu_24_rust_msrv:
     runs-on: ubuntu-24.04
     needs: commit_list
@@ -117,6 +120,9 @@ jobs:
 
     - name: Run the sandboxer example with FS-only restrictions
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/verbose-write-tmp.json true
+
+    - name: Run the sandboxer example with scope restrictions
+      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/mini-scoped.json true
 
   ubuntu_24_rust_stable:
     runs-on: ubuntu-24.04

--- a/examples/mini-scoped.json
+++ b/examples/mini-scoped.json
@@ -1,0 +1,14 @@
+{
+  "ruleset": [
+    {
+      "handledAccessNet": [
+        "v6.all"
+      ]
+    },
+    {
+      "scoped": [
+        "v6.all"
+      ]
+    }
+  ]
+}

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     let ruleset = config.build_ruleset()?;
     let status = ruleset.restrict_self()?;
     if status.ruleset == RulesetStatus::NotEnforced {
-        bail!("Landlock is not supported by the running kernel.");
+        bail!("None of the restrictions can be enforced with the running kernel.");
     }
 
     // clap guarantees that there is at least one element in command.

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -41,7 +41,10 @@
         "ioctl_dev",
         "v5.all",
         "v5.read_execute",
-        "v5.read_write"
+        "v5.read_write",
+        "v6.all",
+        "v6.read_execute",
+        "v6.read_write"
       ]
     },
     "accessNet": {
@@ -50,7 +53,16 @@
         "bind_tcp",
         "connect_tcp",
         "v4.all",
-        "v5.all"
+        "v5.all",
+        "v6.all"
+      ]
+    },
+    "scope": {
+      "type": "string",
+      "enum": [
+        "abstract_unix_socket",
+        "signal",
+        "v6.all"
       ]
     }
   },
@@ -85,6 +97,20 @@
             },
             "required": [
               "handledAccessNet"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "scoped": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/scope"
+                }
+              }
+            },
+            "required": [
+              "scoped"
             ],
             "additionalProperties": false
           }


### PR DESCRIPTION
Add support for Landlock ABI 6: https://github.com/landlock-lsm/rust-landlock/pull/98

Add CI test for scope restrictions.

Requirements: #27 and #28