### PR TITLE
Improve tests with JSON schema validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = ["ffi"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+# rust-version = "1.74" # is enough without test dependencies
+rust-version = "1.81"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
@@ -37,6 +38,8 @@ toml = { version = "0.8.20", optional = true }
 [dev-dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.28", features = ["derive"] }
+jsonschema = { version = "0.30.0", default-features = false }
+lazy_static = "1.5.0"
 
 [[example]]
 name = "sandboxer"

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,29 +55,25 @@ impl From<JsonConfig> for Config {
             }
         }
 
-        if let Some(path_beneaths) = json.pathBeneath {
-            for path_beneath in path_beneaths {
-                let access: BitFlags<AccessFs> = (&path_beneath.allowedAccess).into();
-                for parent in path_beneath.parent {
-                    config
-                        .rules_path_beneath
-                        .entry(PathBuf::from(parent))
-                        .and_modify(|a| *a |= access)
-                        .or_insert(access);
-                }
+        for path_beneath in json.pathBeneath.unwrap_or_default() {
+            let access: BitFlags<AccessFs> = (&path_beneath.allowedAccess).into();
+            for parent in path_beneath.parent {
+                config
+                    .rules_path_beneath
+                    .entry(PathBuf::from(parent))
+                    .and_modify(|a| *a |= access)
+                    .or_insert(access);
             }
         }
 
-        if let Some(net_ports) = json.netPort {
-            for net_port in net_ports {
-                let access: BitFlags<AccessNet> = (&net_port.allowedAccess).into();
-                for port in net_port.port {
-                    config
-                        .rules_net_port
-                        .entry(port)
-                        .and_modify(|a| *a |= access)
-                        .or_insert(access);
-                }
+        for net_port in json.netPort.unwrap_or_default() {
+            let access: BitFlags<AccessNet> = (&net_port.allowedAccess).into();
+            for port in net_port.port {
+                config
+                    .rules_net_port
+                    .entry(port)
+                    .and_modify(|a| *a |= access)
+                    .or_insert(access);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,7 @@ mod parser;
 
 #[cfg(test)]
 mod tests_parser;
+
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -352,7 +352,7 @@ pub(crate) struct JsonPathBeneath {
 #[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
 #[serde(deny_unknown_fields)]
 struct TomlPathBeneath {
-    pub allowed_access: JsonFsAccessSet,
+    allowed_access: JsonFsAccessSet,
     parent: BTreeSet<String>,
 }
 

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::Config;
 use landlock::{Access, AccessFs, AccessNet, Scope, ABI};
 use serde_json::error::Category;
@@ -6,20 +8,22 @@ use std::path::PathBuf;
 const LATEST_ABI: ABI = ABI::V6;
 
 fn assert_json(data: &str, ret: Result<(), Category>) {
-    let cursor = std::io::Cursor::new(data);
-    let parsing_ret = Config::parse_json(cursor)
-        .map(|_| ())
-        .map_err(|e| e.classify());
-    assert_eq!(parsing_ret, ret);
+    assert_eq!(parse_json(data).map(|_| ()), ret);
 }
 
 fn parse_json(json: &str) -> Result<Config, Category> {
     let cursor = std::io::Cursor::new(json);
-    Config::parse_json(cursor).map_err(|e| e.classify())
+    Config::parse_json(cursor).map_err(|e| {
+        eprintln!("JSON parsing error: {e}");
+        e.classify()
+    })
 }
 
 fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
-    Config::parse_toml(toml)
+    Config::parse_toml(toml).map_err(|e| {
+        eprintln!("TOML parsing error: {e}");
+        e
+    })
 }
 
 fn assert_versions<F>(first_known_version: ABI, ruleset_property: F)


### PR DESCRIPTION
Simplify the `From<JsonConfig>` implementation for `Config` by replacing a conditional `Some` check with `unwrap_or_default()`. Add JSON schema validation for all JSON snippets to ensure consistency and alignment with the schema, using the `jsonschema` and `lazy_static` crates for testing. Refactor test helpers by integrating `parse_json()` into `assert_json()` and improving error reporting for JSON and TOML parsing failures. Restrict the visibility of `TomlPathBeneath.allowed_access` to its module to improve encapsulation.