### PR TITLE
Improve configuration consistency and flexibility 1/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ version](https://landlock.io/rust-landlock/landlock/enum.ABI.html).
 
 ### Flexible configuration
 
-**TODO:**
 The parser should limit error cases as much as possible. One way to achieve that
 is to automatically complete the known properties (e.g., handled access rights
 are automatically completed according to all used access rights).

--- a/examples/mini-scoped.json
+++ b/examples/mini-scoped.json
@@ -3,9 +3,7 @@
     {
       "handledAccessNet": [
         "v6.all"
-      ]
-    },
-    {
+      ],
       "scoped": [
         "v6.all"
       ]

--- a/examples/mini-write-tmp.json
+++ b/examples/mini-write-tmp.json
@@ -3,9 +3,7 @@
     {
       "handledAccessFs": [
         "v5.all"
-      ]
-    },
-    {
+      ],
       "handledAccessNet": [
         "bind_tcp"
       ]

--- a/examples/mini-write-tmp.toml
+++ b/examples/mini-write-tmp.toml
@@ -1,10 +1,8 @@
 [[ruleset]]
 handled_access_fs = ["v5.all"]
-
-[[ruleset]]
 handled_access_net = ["bind_tcp"]
 
-# Main system directories can be read.
+# Main system directories can be red.
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
 parent = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -69,23 +69,27 @@
   "properties": {
     "ruleset": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
           "handledAccessFs": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/accessFs"
             }
           },
           "handledAccessNet": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/accessNet"
             }
           },
           "scoped": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/scope"
             }
@@ -96,17 +100,20 @@
     },
     "pathBeneath": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
           "allowedAccess": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/accessFs"
             }
           },
           "parent": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "type": "string"
             }
@@ -121,17 +128,20 @@
     },
     "netPort": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
           "allowedAccess": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/accessNet"
             }
           },
           "port": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/definitions/uint64"
             }

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -71,50 +71,27 @@
       "type": "array",
       "items": {
         "type": "object",
-        "oneOf": [
-          {
-            "properties": {
-              "handledAccessFs": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/accessFs"
-                }
-              }
-            },
-            "required": [
-              "handledAccessFs"
-            ],
-            "additionalProperties": false
+        "properties": {
+          "handledAccessFs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/accessFs"
+            }
           },
-          {
-            "properties": {
-              "handledAccessNet": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/accessNet"
-                }
-              }
-            },
-            "required": [
-              "handledAccessNet"
-            ],
-            "additionalProperties": false
+          "handledAccessNet": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/accessNet"
+            }
           },
-          {
-            "properties": {
-              "scoped": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/scope"
-                }
-              }
-            },
-            "required": [
-              "scoped"
-            ],
-            "additionalProperties": false
+          "scoped": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/scope"
+            }
           }
-        ]
+        },
+        "additionalProperties": false
       }
     },
     "pathBeneath": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,10 @@ impl From<JsonConfig> for Config {
 
         for path_beneath in json.pathBeneath.unwrap_or_default() {
             let access: BitFlags<AccessFs> = (&path_beneath.allowedAccess).into();
+
+            /* Automatically augment and keep the ruleset consistent. */
+            config.handled_fs |= access;
+
             for parent in path_beneath.parent {
                 config
                     .rules_path_beneath
@@ -68,6 +72,10 @@ impl From<JsonConfig> for Config {
 
         for net_port in json.netPort.unwrap_or_default() {
             let access: BitFlags<AccessNet> = (&net_port.allowedAccess).into();
+
+            /* Automatically augment and keep the ruleset consistent. */
+            config.handled_net |= access;
+
             for port in net_port.port {
                 config
                     .rules_net_port

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub use config::{BuildRulesetError, Config};
 
 mod config;
+mod nonempty;
 mod parser;
 
 #[cfg(test)]

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::iter::FromIterator;
+use std::ops::Deref;
+
+/// Wrapper over BTreeSet that ensures it is not empty after deserialization.
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub(crate) struct NonEmptySet<T>(BTreeSet<T>);
+
+impl<T> Default for NonEmptySet<T> {
+    fn default() -> Self {
+        NonEmptySet(BTreeSet::default())
+    }
+}
+
+impl<'de, T> Deserialize<'de> for NonEmptySet<T>
+where
+    T: Deserialize<'de> + Ord,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let set = BTreeSet::<T>::deserialize(deserializer)?;
+        if set.is_empty() {
+            Err(serde::de::Error::invalid_length(0, &"at least one element"))
+        } else {
+            Ok(NonEmptySet(set))
+        }
+    }
+}
+
+impl<T> Deref for NonEmptySet<T> {
+    type Target = BTreeSet<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> IntoIterator for NonEmptySet<T> {
+    type Item = T;
+    type IntoIter = <BTreeSet<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T> FromIterator<T> for NonEmptySet<T>
+where
+    T: Ord,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -250,91 +250,26 @@ impl From<&JsonScopeSet> for BitFlags<Scope> {
 #[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
-pub(crate) struct JsonRulesetAccessFs {
-    pub(crate) handledAccessFs: JsonFsAccessSet,
+pub(crate) struct JsonRuleset {
+    pub(crate) handledAccessFs: Option<JsonFsAccessSet>,
+    pub(crate) handledAccessNet: Option<JsonNetAccessSet>,
+    pub(crate) scoped: Option<JsonScopeSet>,
 }
 
 #[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
 #[serde(deny_unknown_fields)]
-#[allow(non_snake_case)]
-struct TomlRulesetAccessFs {
-    handled_access_fs: JsonFsAccessSet,
-}
-
-impl From<TomlRulesetAccessFs> for JsonRulesetAccessFs {
-    fn from(toml: TomlRulesetAccessFs) -> Self {
-        Self {
-            handledAccessFs: toml.handled_access_fs,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields)]
-#[allow(non_snake_case)]
-pub(crate) struct JsonRulesetAccessNet {
-    pub(crate) handledAccessNet: JsonNetAccessSet,
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields)]
-#[allow(non_snake_case)]
-struct TomlRulesetAccessNet {
-    handled_access_net: JsonNetAccessSet,
-}
-
-impl From<TomlRulesetAccessNet> for JsonRulesetAccessNet {
-    fn from(toml: TomlRulesetAccessNet) -> Self {
-        Self {
-            handledAccessNet: toml.handled_access_net,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields)]
-#[allow(non_snake_case)]
-pub(crate) struct JsonRulesetScope {
-    pub(crate) scoped: JsonScopeSet,
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields)]
-#[allow(non_snake_case)]
-struct TomlRulesetScope {
-    scoped: JsonScopeSet,
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields, untagged)]
-pub(crate) enum JsonRuleset {
-    Fs(JsonRulesetAccessFs),
-    Net(JsonRulesetAccessNet),
-    Scope(JsonRulesetScope),
-}
-
-#[derive(Debug, Deserialize, Ord, Eq, PartialOrd, PartialEq)]
-#[serde(deny_unknown_fields, untagged)]
-enum TomlRuleset {
-    Fs(TomlRulesetAccessFs),
-    Net(TomlRulesetAccessNet),
-    Scope(TomlRulesetScope),
-}
-
-impl From<TomlRulesetScope> for JsonRulesetScope {
-    fn from(toml: TomlRulesetScope) -> Self {
-        Self {
-            scoped: toml.scoped,
-        }
-    }
+struct TomlRuleset {
+    handled_access_fs: Option<JsonFsAccessSet>,
+    handled_access_net: Option<JsonNetAccessSet>,
+    scoped: Option<JsonScopeSet>,
 }
 
 impl From<TomlRuleset> for JsonRuleset {
     fn from(toml: TomlRuleset) -> Self {
-        match toml {
-            TomlRuleset::Fs(fs) => JsonRuleset::Fs(fs.into()),
-            TomlRuleset::Net(net) => JsonRuleset::Net(net.into()),
-            TomlRuleset::Scope(scope) => JsonRuleset::Scope(scope.into()),
+        Self {
+            handledAccessFs: toml.handled_access_fs,
+            handledAccessNet: toml.handled_access_net,
+            scoped: toml.scoped,
         }
     }
 }

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -98,14 +98,71 @@ where
     }
 }
 
-// FIXME: Such an empty ruleset doesn't make sense and should not be allowed.
+/* Test "invalid length 0, expected at least one element" error. */
+
 #[test]
-fn test_empty_ruleset() {
+fn test_empty_ruleset_array_json() {
     let json = r#"{
-        "ruleset": []
+        "ruleset": [ ]
     }"#;
-    assert_eq!(parse_json(json), Ok(Default::default()),);
+    assert_eq!(parse_json(json), Err(Category::Data));
 }
+
+#[test]
+fn test_empty_handled_access_fs_1() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_empty_handled_access_fs_2() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ ]
+            },
+            {
+                "handledAccessFs": [ "execute" ]
+            },
+            {
+                "handledAccessFs": [ ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data),);
+}
+
+#[test]
+fn test_empty_handled_access_net() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_empty_scoped() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "scoped": [ ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+/* Test ruleset's handledAccessFs. */
 
 #[test]
 fn test_one_handled_access_fs() {
@@ -492,6 +549,8 @@ fn test_normalization_path_beneath() {
         }),
     );
 }
+
+/* Test ruleset's handledAccessNet. */
 
 #[test]
 fn test_one_handled_access_net() {

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -666,8 +666,10 @@ fn test_overlap_net_port() {
     );
 }
 
+/* Test ruleset's properties. */
+
 #[test]
-fn test_inconsistent_handled_access() {
+fn test_mix_handled_access_1() {
     let json = r#"{
         "ruleset": [
             {
@@ -676,8 +678,40 @@ fn test_inconsistent_handled_access() {
             }
         ]
     }"#;
-    assert_eq!(parse_json(json), Err(Category::Data));
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            handled_net: AccessNet::BindTcp.into(),
+            ..Default::default()
+        })
+    );
 }
+
+#[test]
+fn test_mix_handled_access_2() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ],
+                "handledAccessNet": [ "bind_tcp" ]
+            },
+            {
+                "handledAccessNet": [ "connect_tcp" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            handled_net: AccessNet::BindTcp | AccessNet::ConnectTcp,
+            ..Default::default()
+        })
+    );
+}
+
+/* Test ruleset's scoped. */
 
 #[test]
 fn test_one_scoped() {


### PR DESCRIPTION
Part 1/2, relying on test improvements from #31 

Enforce the requirement for non-empty arrays by introducing a `NonEmptySet` type, ensuring that empty JSON arrays fail to deserialize properly. This guarantees that arrays always contain meaningful data. 

Simplify ruleset entries by allowing multiple properties to be defined in a single entry. This change not only reduces complexity in configuration files but also resolves Serde's untagged issue, improving error messages and paving the way for future properties like `cancelSandboxOnUnsupported`.

Add the ability to automatically infer handled access rights, which helps reduce configuration file size while maintaining flexibility for explicitly defined access rights. This update also includes renaming and updating test cases to reflect inferred configurations and adds a new micro-write-tmp.toml example, also checked by the CI.