### PR TITLE
Improve configuration consistency and flexibility 2/2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
     - name: Run the sandboxer example with TOML
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --toml examples/mini-write-tmp.toml true
 
+    - name: Run the sandboxer example with TOML (micro)
+      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --toml examples/micro-write-tmp.toml true
+
     - name: Run the sandboxer example with FS-only restrictions
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/verbose-write-tmp.json true
 

--- a/examples/micro-write-tmp.toml
+++ b/examples/micro-write-tmp.toml
@@ -1,0 +1,17 @@
+# Infered properties:
+# [[ruleset]]
+# handled_access_fs = ["v5.all"]
+# handled_access_net = ["bind_tcp"]
+#
+# We need to be careful to cover all access rights (e.g. v5.read_execute +
+# v5.read_write = v5.all), otherwise the missing accesses would not be denied.
+
+# Main system directories can be red.
+[[path_beneath]]
+allowed_access = ["v5.read_execute"]
+parent = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]
+
+# Only allow writing to /tmp.
+[[path_beneath]]
+allowed_access = ["v5.read_write"]
+parent = ["/tmp"]

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -155,8 +155,22 @@
       }
     }
   },
-  "required": [
-    "ruleset"
+  "anyOf": [
+    {
+      "required": [
+        "ruleset"
+      ]
+    },
+    {
+      "required": [
+        "pathBeneath"
+      ]
+    },
+    {
+      "required": [
+        "netPort"
+      ]
+    }
   ],
   "additionalProperties": false
 }

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -95,6 +95,7 @@
             }
           }
         },
+        "minProperties": 1,
         "additionalProperties": false
       }
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ impl From<NonEmptyStruct<JsonConfig>> for Config {
         let json = json.into_inner();
 
         for ruleset in json.ruleset.unwrap_or_default() {
+            let ruleset = ruleset.into_inner();
             config.handled_fs |= ruleset
                 .handledAccessFs
                 .as_ref()

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -64,7 +64,7 @@ pub(crate) trait NonEmptyStructInner {
     fn is_empty(&self) -> bool;
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct NonEmptyStruct<T>(T)
 where
     T: NonEmptyStructInner;

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -253,6 +253,72 @@ fn test_empty_net_port_number() {
     assert_eq!(parse_json(json), Err(Category::Data));
 }
 
+/* Test "empty ruleset" error. */
+
+#[test]
+fn test_empty_ruleset_json() {
+    let json = r#"{
+        "ruleset": [
+            {}
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_empty_ruleset_toml() {
+    let toml = r#"
+        [[ruleset]]
+    "#;
+    assert!(parse_toml(toml).is_err());
+}
+
+/* Test full ruleset. */
+
+#[test]
+fn test_full_ruleset_1() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ],
+                "handledAccessNet": [ "bind_tcp" ],
+                "scoped": [ "abstract_unix_socket" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            handled_net: AccessNet::BindTcp.into(),
+            scoped: Scope::AbstractUnixSocket.into(),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn test_full_ruleset_2() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessNet": [ "bind_tcp" ],
+                "scoped": [ "abstract_unix_socket" ],
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            handled_fs: AccessFs::Execute.into(),
+            handled_net: AccessNet::BindTcp.into(),
+            scoped: Scope::AbstractUnixSocket.into(),
+            ..Default::default()
+        })
+    );
+}
+
 /* Test ruleset's handledAccessFs. */
 
 #[test]


### PR DESCRIPTION
Part 2/2, following #32 

This part is spitted to enable CI tests to properly run.

This pull request introduces stricter validation for Landlock rulesets and configurations by requiring them to be non-empty. It ensures that rulesets must have at least one property and that configurations must include at least one root element (ruleset, pathBeneath, or netPort). To enforce this, a new `NonEmptyStruct` type is added, ensuring that at least one field in a struct is set when all fields are optional. Additional tests are included to validate these changes, and a new `micro-write-tmp.toml` example is added and tested with the CI.