### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,24 +109,6 @@ jobs:
     - name: Build examples
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo build --all --examples --verbose
 
-    - name: Check golden file changes by ffi/build.rs
-      run: s="$(set -o pipefail; git status --porcelain=1 | tee >(cat >&2))" && [[ -z "$s" ]]
-
-    - name: Run the sandboxer example with JSON
-      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/mini-write-tmp.json true
-
-    - name: Run the sandboxer example with TOML
-      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --toml examples/mini-write-tmp.toml true
-
-    - name: Run the sandboxer example with TOML (micro)
-      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --toml examples/micro-write-tmp.toml true
-
-    - name: Run the sandboxer example with FS-only restrictions
-      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/verbose-write-tmp.json true
-
-    - name: Run the sandboxer example with scope restrictions
-      run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo run --example sandboxer -- --json examples/mini-scoped.json true
-
   ubuntu_24_rust_stable:
     runs-on: ubuntu-24.04
     needs: commit_list
@@ -165,6 +147,15 @@ jobs:
 
     - name: Run the sandboxer example with TOML
       run: rustup run stable cargo run --example sandboxer -- --toml examples/mini-write-tmp.toml true
+
+    - name: Run the sandboxer example with TOML (micro)
+      run: rustup run stable cargo run --example sandboxer -- --toml examples/micro-write-tmp.toml true
+
+    - name: Run the sandboxer example with FS-only restrictions
+      run: rustup run stable cargo run --example sandboxer -- --json examples/verbose-write-tmp.json true
+
+    - name: Run the sandboxer example with scope restrictions
+      run: rustup run stable cargo run --example sandboxer -- --json examples/mini-scoped.json true
 
     - name: Check format
       run: rustup run stable cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ members = ["ffi"]
 
 [workspace.package]
 edition = "2021"
-# rust-version = "1.74" # is enough without test dependencies
-rust-version = "1.81"
+rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,12 +251,12 @@ impl NonEmptyStructInner for JsonRuleset {
     fn is_empty(&self) -> bool {
         self.handledAccessFs
             .as_ref()
-            .map_or(true, |set| set.is_empty())
+            .is_none_or(|set| set.is_empty())
             && self
                 .handledAccessNet
                 .as_ref()
-                .map_or(true, |set| set.is_empty())
-            && self.scoped.as_ref().map_or(true, |set| set.is_empty())
+                .is_none_or(|set| set.is_empty())
+            && self.scoped.as_ref().is_none_or(|set| set.is_empty())
     }
 }
 
@@ -275,12 +275,12 @@ impl NonEmptyStructInner for TomlRuleset {
     fn is_empty(&self) -> bool {
         self.handled_access_fs
             .as_ref()
-            .map_or(true, |set| set.is_empty())
+            .is_none_or(|set| set.is_empty())
             && self
                 .handled_access_net
                 .as_ref()
-                .map_or(true, |set| set.is_empty())
-            && self.scoped.as_ref().map_or(true, |set| set.is_empty())
+                .is_none_or(|set| set.is_empty())
+            && self.scoped.as_ref().is_none_or(|set| set.is_empty())
     }
 }
 
@@ -358,9 +358,9 @@ impl NonEmptyStructInner for JsonConfig {
     const ERROR_MESSAGE: &'static str = "empty configuration";
 
     fn is_empty(&self) -> bool {
-        self.ruleset.as_ref().map_or(true, |set| set.is_empty())
-            && self.pathBeneath.as_ref().map_or(true, |set| set.is_empty())
-            && self.netPort.as_ref().map_or(true, |set| set.is_empty())
+        self.ruleset.as_ref().is_none_or(|set| set.is_empty())
+            && self.pathBeneath.as_ref().is_none_or(|set| set.is_empty())
+            && self.netPort.as_ref().is_none_or(|set| set.is_empty())
     }
 }
 
@@ -377,12 +377,9 @@ impl NonEmptyStructInner for TomlConfig {
     const ERROR_MESSAGE: &'static str = "empty configuration";
 
     fn is_empty(&self) -> bool {
-        self.ruleset.as_ref().map_or(true, |set| set.is_empty())
-            && self
-                .path_beneath
-                .as_ref()
-                .map_or(true, |set| set.is_empty())
-            && self.net_port.as_ref().map_or(true, |set| set.is_empty())
+        self.ruleset.as_ref().is_none_or(|set| set.is_empty())
+            && self.path_beneath.as_ref().is_none_or(|set| set.is_empty())
+            && self.net_port.as_ref().is_none_or(|set| set.is_empty())
     }
 }
 


### PR DESCRIPTION
Bump MSRV to 1.82 for test dependencies.

See https://github.com/landlock-lsm/landlockconfig/actions/runs/15146921686/job/42616457005

```
Run rustup run 1.81 cargo build --all --tests --verbose
error: rustc 1.81.0 is not supported by the following packages:
  icu_collections@2.0.0 requires rustc 1.82
  icu_locale_core@2.0.0 requires rustc 1.82
  icu_normalizer@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_properties@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_provider@2.0.0 requires rustc 1.82
  idna_adapter@1.2.1 requires rustc 1.82
  litemap@0.8.0 requires rustc 1.82
  zerotrie@0.2.2 requires rustc 1.82
  zerovec@0.11.2 requires rustc 1.82
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.81.0
```