### PR TITLE
Handle variables with literal values

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ can be used to test the library implementation against a set of valid and
 invalid samples. This could also be used to test Landlock libraries to make sure
 the execution traces are similar.
 
-## Example
+## Sandboxer example
 
 Here are the steps to build and use the sandboxer example:
 ```sh
@@ -123,3 +123,38 @@ cargo run --example sandboxer -- --json examples/mini-write-tmp.json sh
 ```
 
 A new dedicated tool will be published soon.
+
+## TOML configuration example
+
+Here is an example of a [TOML configuration](examples/micro-var.toml) that uses
+variables, access right groups, and list of directory hierarchies for
+conciseness.
+
+```toml
+[[variable]]
+name = "tmp"
+literal = ["/tmp", "/var/tmp"]
+
+[[variable]]
+name = "home"
+literal = ["/root", "/home"]
+
+[[variable]]
+name = "config"
+literal = ["/etc"]
+
+# Main system directories can be read, including the current path.
+[[path_beneath]]
+allowed_access = ["v5.read_execute"]
+parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
+
+# Only allow writing to /tmp and /var/tmp .
+[[path_beneath]]
+allowed_access = ["v5.read_write"]
+parent = ["${tmp}", "${home}"]
+```
+
+We can get a view of the created Landlock rules:
+```sh
+cargo run --example sandboxer -- --toml examples/micro-var.toml --debug date
+```

--- a/examples/micro-var.toml
+++ b/examples/micro-var.toml
@@ -1,0 +1,21 @@
+[[variable]]
+name = "tmp"
+literal = ["/tmp", "/var/tmp"]
+
+[[variable]]
+name = "home"
+literal = ["/root", "/home"]
+
+[[variable]]
+name = "config"
+literal = ["/etc"]
+
+# Main system directories can be read, including the current path.
+[[path_beneath]]
+allowed_access = ["v5.read_execute"]
+parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
+
+# Only allow writing to /tmp and /var/tmp .
+[[path_beneath]]
+allowed_access = ["v5.read_write"]
+parent = ["${tmp}", "${home}"]

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -63,7 +63,11 @@ fn main() -> anyhow::Result<()> {
         eprintln!("{:#?}", config);
     }
 
-    let ruleset = config.build_ruleset()?;
+    let (ruleset, rule_errors) = config.build_ruleset()?;
+    if args.debug {
+        eprintln!("Ignored rule errors: {:#?}", rule_errors);
+    }
+
     let status = ruleset.restrict_self()?;
     if status.ruleset == RulesetStatus::NotEnforced {
         bail!("None of the restrictions can be enforced with the running kernel.");

--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -18,6 +18,8 @@ struct Args {
     json: Option<String>,
     #[arg(short, long, required_unless_present = "json")]
     toml: Option<String>,
+    #[arg(short, long)]
+    debug: bool,
     #[arg(required = true)]
     command: Vec<String>,
 }
@@ -56,6 +58,10 @@ fn main() -> anyhow::Result<()> {
             Config::parse_toml(data.as_str())?
         }
     };
+
+    if args.debug {
+        eprintln!("{:#?}", config);
+    }
 
     let ruleset = config.build_ruleset()?;
     let status = ruleset.restrict_self()?;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn landlockconfig_build_ruleset(config: *const Config, fla
 
     unsafe { &*config }
         .build_ruleset()
-        .map(|r| {
+        .map(|(r, _)| {
             let fd: Option<OwnedFd> = r.into();
             fd.map(|fd| fd.into_raw_fd()).unwrap_or(-1)
         })

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -67,6 +67,29 @@
     }
   },
   "properties": {
+    "variable": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "literal": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
     "ruleset": {
       "type": "array",
       "minItems": 1,
@@ -157,6 +180,11 @@
     }
   },
   "anyOf": [
+    {
+      "required": [
+        "variable"
+      ]
+    },
     {
       "required": [
         "ruleset"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use config::{BuildRulesetError, Config, RuleError};
 mod config;
 mod nonempty;
 mod parser;
+mod variable;
 
 #[cfg(test)]
 mod tests_helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ mod nonempty;
 mod parser;
 
 #[cfg(test)]
+mod tests_helpers;
+
+#[cfg(test)]
 mod tests_parser;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub use config::{BuildRulesetError, Config};
+pub use config::{BuildRulesetError, Config, RuleError};
 
 mod config;
 mod nonempty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,8 @@ mod tests_helpers;
 mod tests_parser;
 
 #[cfg(test)]
+mod tests_variable;
+
+#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;

--- a/src/tests_helpers.rs
+++ b/src/tests_helpers.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::Config;
+use landlock::ABI;
+use serde_json::error::Category;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::{env, fs};
+
+pub(crate) const LATEST_ABI: ABI = ABI::V6;
+
+lazy_static! {
+    static ref JSON_VALIDATOR: jsonschema::Validator = {
+        let crate_dir = PathBuf::from(
+            env::var("CARGO_MANIFEST_DIR")
+                .expect("The environment variable CARGO_MANIFEST_DIR is not set"),
+        );
+        let schema_path = crate_dir.join("schema/landlockconfig.json");
+        let schema_str =
+            fs::read_to_string(schema_path).expect("Failed to read the JSON schema file");
+        let schema: Value = serde_json::from_str(&schema_str).expect("Invalid JSON");
+        jsonschema::validator_for(&schema).expect("Invalid JSON schema")
+    };
+}
+
+pub(crate) fn validate_json(json: &str) -> Result<(), ()> {
+    let json = serde_json::from_str::<Value>(json).expect("Invalid JSON");
+    JSON_VALIDATOR.validate(&json).map(|_| ()).map_err(|e| {
+        eprintln!("JSON schema validation error: {e}");
+    })
+}
+
+pub(crate) fn assert_json(data: &str, ret: Result<(), Category>) {
+    assert_eq!(parse_json(data).map(|_| ()), ret);
+}
+
+pub(crate) fn parse_json(json: &str) -> Result<Config, Category> {
+    let cursor = std::io::Cursor::new(json);
+    let parsing = Config::parse_json(cursor).map_err(|e| {
+        eprintln!("JSON parsing error: {e}");
+        e.classify()
+    });
+
+    // Ensures the JSON schema is consistent and stays up-to-date with the crate.
+    let valid = validate_json(json);
+    if parsing.is_ok() != valid.is_ok() {
+        panic!("Inconsistent validation: parser and schema validator disagree");
+    }
+    parsing
+}
+
+pub(crate) fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
+    Config::parse_toml(toml).map_err(|e| {
+        eprintln!("TOML parsing error: {e}");
+        e
+    })
+}

--- a/src/tests_helpers.rs
+++ b/src/tests_helpers.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::config::{ParseJsonError, ParseTomlError};
 use crate::Config;
 use landlock::ABI;
 use serde_json::error::Category;
@@ -34,22 +35,34 @@ pub(crate) fn assert_json(data: &str, ret: Result<(), Category>) {
     assert_eq!(parse_json(data).map(|_| ()), ret);
 }
 
-pub(crate) fn parse_json(json: &str) -> Result<Config, Category> {
+// TODO: Return ParseJsonError
+pub(crate) fn parse_json_schema(json: &str, with_schema: bool) -> Result<Config, Category> {
     let cursor = std::io::Cursor::new(json);
     let parsing = Config::parse_json(cursor).map_err(|e| {
         eprintln!("JSON parsing error: {e}");
-        e.classify()
+        match e {
+            ParseJsonError::SerdeJson(e) => e.classify(),
+            _ => Category::Data,
+        }
     });
 
     // Ensures the JSON schema is consistent and stays up-to-date with the crate.
     let valid = validate_json(json);
-    if parsing.is_ok() != valid.is_ok() {
-        panic!("Inconsistent validation: parser and schema validator disagree");
+    if with_schema {
+        if parsing.is_ok() != valid.is_ok() {
+            panic!("Inconsistent validation: parser and schema validator disagree");
+        }
+    } else if parsing.is_ok() == valid.is_ok() {
+        panic!("Consistent validation: parser and schema validator agree");
     }
     parsing
 }
 
-pub(crate) fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
+pub(crate) fn parse_json(json: &str) -> Result<Config, Category> {
+    parse_json_schema(json, true)
+}
+
+pub(crate) fn parse_toml(toml: &str) -> Result<Config, ParseTomlError> {
     Config::parse_toml(toml).map_err(|e| {
         eprintln!("TOML parsing error: {e}");
         e

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{
-    tests_helpers::{assert_json, parse_json, parse_toml, validate_json, LATEST_ABI},
-    Config,
-};
+use crate::tests_helpers::{assert_json, parse_json, parse_toml, validate_json, LATEST_ABI};
+use crate::Config;
 use landlock::{Access, AccessFs, AccessNet, Scope, ABI};
 use serde_json::error::Category;
 use std::path::PathBuf;

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,34 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::Config;
+use crate::{
+    tests_helpers::{assert_json, parse_json, parse_toml, validate_json, LATEST_ABI},
+    Config,
+};
 use landlock::{Access, AccessFs, AccessNet, Scope, ABI};
 use serde_json::error::Category;
-use serde_json::Value;
 use std::path::PathBuf;
-use std::{env, fs};
-
-const LATEST_ABI: ABI = ABI::V6;
-
-lazy_static! {
-    static ref JSON_VALIDATOR: jsonschema::Validator = {
-        let crate_dir = PathBuf::from(
-            env::var("CARGO_MANIFEST_DIR")
-                .expect("The environment variable CARGO_MANIFEST_DIR is not set"),
-        );
-        let schema_path = crate_dir.join("schema/landlockconfig.json");
-        let schema_str =
-            fs::read_to_string(schema_path).expect("Failed to read the JSON schema file");
-        let schema: Value = serde_json::from_str(&schema_str).expect("Invalid JSON");
-        jsonschema::validator_for(&schema).expect("Invalid JSON schema")
-    };
-}
-
-fn validate_json(json: &str) -> Result<(), ()> {
-    let json = serde_json::from_str::<Value>(json).expect("Invalid JSON");
-    JSON_VALIDATOR.validate(&json).map(|_| ()).map_err(|e| {
-        eprintln!("JSON schema validation error: {e}");
-    })
-}
 
 #[test]
 fn test_json_schema() {
@@ -37,32 +15,6 @@ fn test_json_schema() {
     }"#;
 
     validate_json(test_json).expect_err("JSON schema validator should return a type error")
-}
-
-fn assert_json(data: &str, ret: Result<(), Category>) {
-    assert_eq!(parse_json(data).map(|_| ()), ret);
-}
-
-fn parse_json(json: &str) -> Result<Config, Category> {
-    let cursor = std::io::Cursor::new(json);
-    let parsing = Config::parse_json(cursor).map_err(|e| {
-        eprintln!("JSON parsing error: {e}");
-        e.classify()
-    });
-
-    // Ensures the JSON schema is consistent and stays up-to-date with the crate.
-    let valid = validate_json(json);
-    if parsing.is_ok() != valid.is_ok() {
-        panic!("Inconsistent validation: parser and schema validator disagree");
-    }
-    parsing
-}
-
-fn parse_toml(toml: &str) -> Result<Config, toml::de::Error> {
-    Config::parse_toml(toml).map_err(|e| {
-        eprintln!("TOML parsing error: {e}");
-        e
-    })
 }
 
 fn assert_versions<F>(first_known_version: ABI, ruleset_property: F)

--- a/src/tests_variable.rs
+++ b/src/tests_variable.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::{
-    tests_helpers::{parse_json, parse_toml},
+    tests_helpers::{parse_json, parse_json_schema, parse_toml},
+    variable::Variables,
     Config,
 };
+use landlock::AccessFs;
 use serde_json::error::Category;
+use std::path::PathBuf;
 
 #[test]
 fn test_empty_variable() {
@@ -45,10 +48,11 @@ fn test_without_value() {
             }
         ]
     }"#;
+    let empty: &[&str] = &[];
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            variables: [("bar".to_string(), [].into())].into(),
+            variables: Variables::try_from([("bar", empty)]).unwrap(),
             ..Default::default()
         })
     );
@@ -67,7 +71,7 @@ fn test_one_variable_json() {
     assert_eq!(
         parse_json(json),
         Ok(Config {
-            variables: [("bar".to_string(), ["foo".to_string()].into())].into(),
+            variables: Variables::try_from([("bar", ["foo"])]).unwrap(),
             ..Default::default()
         })
     );
@@ -85,8 +89,344 @@ fn test_one_variable_toml() {
     assert_eq!(
         parse_toml(toml).unwrap(),
         Config {
-            variables: [("bar".to_string(), ["foo".to_string()].into())].into(),
+            variables: Variables::try_from([("bar", ["foo"])]).unwrap(),
             ..Default::default()
         }
+    );
+}
+
+#[test]
+fn test_one_variable_simple_1() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            variables: Variables::try_from([("foo", vec!["a", "b"])]).unwrap(),
+            ..Default::default()
+        })
+    );
+}
+
+fn json_var_declaration(name: &str) -> String {
+    format!(
+        r#"{{
+            "variable": [
+                {{
+                    "name": "{}",
+                    "literal": [ "value" ]
+                }}
+            ]
+        }}"#,
+        name
+    )
+}
+
+fn json_var_use(name: &str) -> String {
+    format!(
+        r#"{{
+            "pathBeneath": [
+                {{
+                    "allowedAccess": [ "execute" ],
+                    "parent": [ "${{{}}}" ]
+            }}
+            ]
+        }}"#,
+        name
+    )
+}
+
+fn assert_invalid_var_name(name: &str) {
+    assert_eq!(
+        parse_json_schema(&json_var_declaration(name), false),
+        Err(Category::Data)
+    );
+
+    // Fails because the variable is not defined, but also because the name is
+    // invalid.
+    assert_eq!(
+        parse_json_schema(&json_var_use(name), false),
+        Err(Category::Data)
+    );
+}
+
+#[test]
+fn test_variable_name_invalid() {
+    // Start with digit
+    assert_invalid_var_name("1foo");
+
+    // Start with underscore
+    assert_invalid_var_name("_foo");
+
+    // Single non-ascii alphabetic character
+    assert_invalid_var_name("À");
+
+    // Contain non-letter character
+    assert_invalid_var_name("e€");
+
+    // Leading space
+    assert_invalid_var_name(" foo");
+
+    // Space in middle
+    assert_invalid_var_name("foo bar");
+
+    // Trailing space
+    assert_invalid_var_name("foo ");
+
+    // Contain hyphen
+    assert_invalid_var_name("foo-bar");
+
+    // Contain non-ASCII characters
+    assert_invalid_var_name("foo_çë");
+}
+
+fn assert_valid_var_name(name: &str) {
+    assert_eq!(
+        parse_json(&json_var_declaration(name)),
+        Ok(Config {
+            variables: Variables::try_from([(name, ["value"])]).unwrap(),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn test_variable_name_valid() {
+    // Single uppercase letter
+    assert_valid_var_name("F");
+
+    // All uppercase
+    assert_valid_var_name("FOO");
+
+    // Capitalized first letter
+    assert_valid_var_name("Foo");
+
+    // Single lowercase letter
+    assert_valid_var_name("f");
+
+    // Mixed case
+    assert_valid_var_name("fOo");
+
+    // Standard lowercase identifier
+    assert_valid_var_name("foo");
+
+    // Trailing underscore
+    assert_valid_var_name("foo_");
+
+    // Multiple consecutive underscores
+    assert_valid_var_name("foo__bar");
+
+    // Middle underscore
+    assert_valid_var_name("foo_bar");
+}
+
+#[test]
+fn test_variable_name_valid_single_letter() {
+    assert_eq!(
+        parse_json(&json_var_declaration("a")),
+        Ok(Config {
+            variables: Variables::try_from([("a", ["value"])]).unwrap(),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn test_one_variable_template_error_1() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${a" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json_schema(json, false), Err(Category::Data),);
+}
+
+#[test]
+fn test_one_variable_template_missing() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}/${bar}" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json_schema(json, false), Err(Category::Data),);
+}
+
+#[test]
+fn test_one_variable_json_toml_template() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [
+                    "a",
+                    "b"
+                ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}" ]
+            }
+        ]
+    }"#;
+    let json_reverse = r#"{
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}" ]
+            }
+        ],
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [
+                    "b",
+                    "a"
+                ]
+            }
+        ]
+    }"#;
+
+    let toml = r#"
+        [[variable]]
+        name = "foo"
+        literal = [
+            "a",
+            "b",
+        ]
+
+        [[path_beneath]]
+        allowed_access = [ "execute" ]
+        parent = [ "${foo}" ]
+    "#;
+    let toml_reverse = r#"
+        [[path_beneath]]
+        allowed_access = [ "execute" ]
+        parent = [ "${foo}" ]
+
+        [[variable]]
+        name = "foo"
+        literal = [
+            "b",
+            "a",
+        ]
+    "#;
+
+    let ret = Config {
+        variables: Variables::try_from([("foo", vec!["a", "b"])]).unwrap(),
+        handled_fs: AccessFs::Execute.into(),
+        rules_path_beneath: [
+            (PathBuf::from("a"), AccessFs::Execute.into()),
+            (PathBuf::from("b"), AccessFs::Execute.into()),
+        ]
+        .into(),
+        ..Default::default()
+    };
+    assert_eq!(parse_json(json).unwrap(), ret);
+    assert_eq!(parse_json(json_reverse).unwrap(), ret);
+    assert_eq!(parse_toml(toml).unwrap(), ret);
+    assert_eq!(parse_toml(toml_reverse).unwrap(), ret);
+}
+
+#[test]
+fn test_two_variable_template() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            },
+            {
+                "name": "bar",
+                "literal": [ "X", "Y", "Z" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "before/${foo}/${bar}/after" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            variables: Variables::try_from([("foo", vec!["a", "b"]), ("bar", vec!["X", "Y", "Z"])])
+                .unwrap(),
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [
+                (PathBuf::from("before/a/X/after"), AccessFs::Execute.into()),
+                (PathBuf::from("before/a/Y/after"), AccessFs::Execute.into()),
+                (PathBuf::from("before/a/Z/after"), AccessFs::Execute.into()),
+                (PathBuf::from("before/b/X/after"), AccessFs::Execute.into()),
+                (PathBuf::from("before/b/Y/after"), AccessFs::Execute.into()),
+                (PathBuf::from("before/b/Z/after"), AccessFs::Execute.into()),
+            ]
+            .into(),
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn test_special_characters() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "bar" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [
+                    "$$",
+                    "$${foo}",
+                    "$${${foo}",
+                    "{${foo}"
+                ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            variables: Variables::try_from([("foo", ["bar"])]).unwrap(),
+            handled_fs: AccessFs::Execute.into(),
+            rules_path_beneath: [
+                (PathBuf::from("$"), AccessFs::Execute.into()),
+                (PathBuf::from("${foo}"), AccessFs::Execute.into()),
+                (PathBuf::from("${bar"), AccessFs::Execute.into()),
+                (PathBuf::from("{bar"), AccessFs::Execute.into()),
+            ]
+            .into(),
+            ..Default::default()
+        })
     );
 }

--- a/src/tests_variable.rs
+++ b/src/tests_variable.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    tests_helpers::{parse_json, parse_toml},
+    Config,
+};
+use serde_json::error::Category;
+
+#[test]
+fn test_empty_variable() {
+    let json = r#"{
+        "variable": [ ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_empty_variable_item() {
+    let json = r#"{
+        "variable": [
+            {}
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_empty_variable_name() {
+    let json = r#"{
+        "variable": [
+            {
+                "literal": [ "foo" ]
+            }
+        ]
+    }"#;
+    assert_eq!(parse_json(json), Err(Category::Data));
+}
+
+#[test]
+fn test_without_value() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "bar"
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            variables: [("bar".to_string(), [].into())].into(),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn test_one_variable_json() {
+    let json = r#"{
+        "variable": [
+            {
+                "name": "bar",
+                "literal": [ "foo" ]
+            }
+        ]
+    }"#;
+    assert_eq!(
+        parse_json(json),
+        Ok(Config {
+            variables: [("bar".to_string(), ["foo".to_string()].into())].into(),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn test_one_variable_toml() {
+    let toml = r#"
+        [[variable]]
+        name = "bar"
+        literal = [
+            "foo",
+        ]
+    "#;
+    assert_eq!(
+        parse_toml(toml).unwrap(),
+        Config {
+            variables: [("bar".to_string(), ["foo".to_string()].into())].into(),
+            ..Default::default()
+        }
+    );
+}

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::parser::{TemplateString, TemplateToken};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    iter::Peekable,
+    str::FromStr,
+};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Name(String);
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for Name {
+    type Err = NameError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(NameError::Empty);
+        }
+
+        if !s.chars().next().unwrap().is_ascii_alphabetic() {
+            return Err(NameError::InvalidFirstCharacter(s.to_string()));
+        }
+
+        if !s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            return Err(NameError::InvalidCharacter(s.to_string()));
+        }
+
+        Ok(Self(s.to_string()))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum NameError {
+    #[error("name cannot be empty")]
+    Empty,
+    #[error("invalid first character in name (must be ASCII alphabetic): {0}")]
+    InvalidFirstCharacter(String),
+    #[error("invalid character(s) in name (must be ASCII alphanumeric or '_'): {0}")]
+    InvalidCharacter(String),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct Variables(BTreeMap<Name, BTreeSet<String>>);
+
+#[derive(Debug, Error)]
+pub enum ExtrapolateError {
+    #[error("variable '{0}' not found")]
+    VariableNotFound(Name),
+    #[error(transparent)]
+    InvalidName(#[from] NameError),
+}
+
+impl Variables {
+    pub(crate) fn insert(&mut self, key: Name, values: BTreeSet<String>) {
+        self.0.insert(key, values);
+    }
+
+    // TODO: Return references instead of cloning.
+    pub(crate) fn extrapolate(
+        &self,
+        template: &TemplateString,
+    ) -> Result<Vec<BTreeSet<String>>, ExtrapolateError> {
+        template
+            .0
+            .iter()
+            .map(|token| match token {
+                TemplateToken::Text(text) => Ok([text.to_string()].into()),
+                TemplateToken::Var(name) => self
+                    .0
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| ExtrapolateError::VariableNotFound(name.clone())),
+            })
+            .collect()
+    }
+
+    // Used by tests_parser.rs
+    #[allow(dead_code)]
+    pub(crate) fn try_from<K, V, S, I>(list: I) -> Result<Self, NameError>
+    where
+        K: AsRef<str>,
+        V: IntoIterator<Item = S>,
+        S: AsRef<str>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let mut map = BTreeMap::new();
+        for (key, values) in list {
+            let name = Name::from_str(key.as_ref())?;
+            map.insert(
+                name,
+                values
+                    .into_iter()
+                    .map(|s| s.as_ref().to_string())
+                    .collect::<BTreeSet<_>>(),
+            );
+        }
+        Ok(Self(map))
+    }
+}
+
+struct SetIterReset<'a, T>
+where
+    T: 'a,
+{
+    set: &'a BTreeSet<T>,
+    iter: Peekable<std::collections::btree_set::Iter<'a, T>>,
+}
+
+impl<'a, T> SetIterReset<'a, T>
+where
+    T: 'a,
+{
+    fn new(set: &'a BTreeSet<T>) -> Self {
+        Self {
+            set,
+            iter: set.iter().peekable(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.iter = self.set.iter().peekable();
+    }
+}
+
+pub(crate) struct VecStringIterator<'a, T> {
+    vec: Vec<SetIterReset<'a, T>>,
+    is_final: bool,
+}
+
+impl<'a, T> VecStringIterator<'a, T> {
+    pub(crate) fn new(vec: &'a [BTreeSet<T>]) -> Self {
+        Self {
+            vec: vec
+                .iter()
+                .map(|set| SetIterReset::new(set))
+                .collect::<Vec<_>>(),
+            is_final: false,
+        }
+    }
+}
+
+/// Iterator that generates the Cartesian product of multiple sets, producing
+/// all possible combinations as concatenated strings in lexicographic order.
+impl<'a, T> Iterator for VecStringIterator<'a, T>
+where
+    T: AsRef<str> + 'a,
+{
+    // TODO: Use PathBuf, canonicalize, and filter to avoid consecutive returned paths to be the
+    // same (e.g. peekable + dedup).
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_final {
+            return None;
+        }
+
+        let mut ret = vec![];
+        let mut carry = true;
+        for set in self.vec.iter_mut().rev() {
+            if let Some(value) = set.iter.peek() {
+                ret.push((*value).as_ref());
+            } else {
+                return None;
+            }
+            if carry {
+                set.iter.next();
+                if set.iter.peek().is_some() {
+                    carry = false;
+                } else {
+                    set.reset();
+                }
+            }
+        }
+
+        if carry {
+            self.is_final = true;
+            if ret.is_empty() {
+                return None;
+            }
+        }
+
+        ret.reverse();
+        Some(ret.join(""))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vec_string_iterator_empty_vec() {
+        let vec: Vec<BTreeSet<String>> = vec![];
+        let mut iter = VecStringIterator::new(&vec);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_vec_string_iterator_single_empty_set() {
+        let set = BTreeSet::<String>::new();
+        let vec = vec![set];
+        let mut iter = VecStringIterator::new(&vec);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_vec_string_iterator_one_set() {
+        // BTreeSet are automatically sorted, so we should not rely on this order.
+        let set: BTreeSet<_> = ["b", "a"].into();
+        let vec = vec![set];
+        let mut iter = VecStringIterator::new(&vec);
+
+        assert_eq!(iter.next(), Some("a".to_string()));
+        assert_eq!(iter.next(), Some("b".to_string()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_vec_string_iterator_two_sets() {
+        let set1: BTreeSet<_> = ["a", "b"].into();
+        let set2: BTreeSet<_> = ["2", "1", "3"].into();
+        let vec = vec![set1, set2];
+        let iter = VecStringIterator::new(&vec);
+
+        // Collect all results and sort for comparison
+        let results: Vec<String> = iter.collect();
+
+        // Cartesian product of the sets.
+        let expected = ["a1", "a2", "a3", "b1", "b2", "b3"].map(|s| s.to_string());
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_vec_string_iterator_three_sets() {
+        let set1: BTreeSet<_> = ["a", "b"].into();
+        let set2: BTreeSet<_> = ["2", "1", "3"].into();
+        let set3: BTreeSet<_> = ["Y", "X"].into();
+        let vec = vec![set1, set2, set3];
+        let iter = VecStringIterator::new(&vec);
+
+        // Collect all results and sort for comparison
+        let results: Vec<String> = iter.collect();
+
+        // Cartesian product of the sets.
+        let expected = [
+            "a1X", "a1Y", "a2X", "a2Y", "a3X", "a3Y", "b1X", "b1Y", "b2X", "b2Y", "b3X", "b3Y",
+        ]
+        .map(|s| s.to_string());
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_vec_string_iterator_with_empty_set() {
+        let set1: BTreeSet<_> = ["a"].into();
+        let set2 = BTreeSet::new();
+        let set3: BTreeSet<_> = ["Y"].into();
+
+        let vec = vec![set1, set2, set3];
+        let mut iter = VecStringIterator::new(&vec);
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+}


### PR DESCRIPTION
Add the foundation to parse and interpret variables. For now, only literal values are handled, but this design will enables us to support other kind of values (e.g. environment variables).

A debug option with some warnings are also added to the example to ease debugging.

Cf. #24 