### PR TITLE
Compose configurations

### DIFF
--- a/examples/sandboxer.rs
+++ b/examples/sandboxer.rs
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
         eprintln!("{:#?}", config);
     }
 
-    let (ruleset, rule_errors) = config.build_ruleset()?;
+    let (ruleset, rule_errors) = config.resolve()?.build_ruleset()?;
     if args.debug {
         eprintln!("Ignored rule errors: {:#?}", rule_errors);
     }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -207,7 +207,12 @@ pub unsafe extern "C" fn landlockconfig_build_ruleset(config: *const Config, fla
         return unwrap_errno(Errno::new(libc::EFAULT));
     }
 
-    unsafe { &*config }
+    // TODO: Avoid cloning the config.
+    let resolved = match unsafe { &*config }.clone().resolve() {
+        Ok(resolved) => resolved,
+        Err(e) => return unwrap_errno(e),
+    };
+    resolved
         .build_ruleset()
         .map(|(r, _)| {
             let fd: Option<OwnedFd> = r.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ mod parser;
 mod variable;
 
 #[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+#[cfg(test)]
 mod tests_helpers;
 
 #[cfg(test)]
@@ -17,5 +21,4 @@ mod tests_parser;
 mod tests_variable;
 
 #[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
+mod tests_compose;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,16 @@ pub enum TemplateToken {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TemplateString(pub Vec<TemplateToken>);
 
+impl TemplateString {
+    #[cfg(test)]
+    pub(crate) fn from_text<T>(text: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self(vec![TemplateToken::Text(text.into())])
+    }
+}
+
 impl std::fmt::Display for TemplateString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for token in &self.0 {

--- a/src/tests_compose.rs
+++ b/src/tests_compose.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{config::ResolvedConfig, tests_helpers::parse_json, Config};
+use landlock::AccessFs;
+use std::path::PathBuf;
+
+fn get_compositions(json1: &str, json2: &str) -> (Config, Config) {
+    let mut c1 = parse_json(json1).unwrap();
+    c1.compose(&parse_json(json2).unwrap());
+
+    let mut c2 = parse_json(json2).unwrap();
+    c2.compose(&parse_json(json1).unwrap());
+
+    (c1, c2)
+}
+
+#[test]
+fn test_compose_exclusive() {
+    let json1 = r#"{
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "a" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "a" ]
+            },
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "b" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    // Test commutativity
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [
+                (PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("b"), AccessFs::Execute | AccessFs::ReadFile),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn test_compose_complement1() {
+    let json1 = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "read_file" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "a" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "a" ]
+            },
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "b" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [
+                (PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("b"), AccessFs::Execute | AccessFs::ReadFile),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn test_compose_complement2() {
+    let json1 = r#"{
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "a" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "a" ]
+            },
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "b" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [
+                (PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("b"), AccessFs::ReadFile.into()),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn test_compose_standalone_variable() {
+    let json1 = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "a" ]
+            },
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "b" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [
+                (PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("b"), AccessFs::Execute | AccessFs::ReadFile),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn test_compose_shared_variable() {
+    let json1 = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a", "b" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ],
+        "variable": [
+            {
+                "name": "foo"
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "${foo}" ]
+            },
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "x/${foo}" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [
+                (PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("b"), AccessFs::Execute | AccessFs::ReadFile),
+                (PathBuf::from("x/a"), AccessFs::ReadFile.into()),
+                (PathBuf::from("x/b"), AccessFs::ReadFile.into()),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn test_compose_same_resolved_path() {
+    let json1 = r#"{
+        "variable": [
+            {
+                "name": "foo",
+                "literal": [ "a" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "execute" ],
+                "parent": [ "${foo}" ]
+            }
+        ]
+    }"#;
+    let json2 = r#"{
+        "variable": [
+            {
+                "name": "bar",
+                "literal": [ "a" ]
+            }
+        ],
+        "pathBeneath": [
+            {
+                "allowedAccess": [ "read_file" ],
+                "parent": [ "${bar}" ]
+            }
+        ]
+    }"#;
+
+    let (c1, c2) = get_compositions(json1, json2);
+    assert_eq!(c1, c2);
+    assert_eq!(
+        c1.resolve().unwrap(),
+        ResolvedConfig {
+            handled_fs: AccessFs::Execute | AccessFs::ReadFile,
+            rules_path_beneath: [(PathBuf::from("a"), AccessFs::Execute | AccessFs::ReadFile)]
+                .into(),
+            ..Default::default()
+        }
+    );
+}

--- a/src/tests_parser.rs
+++ b/src/tests_parser.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::config::ResolvedConfig;
 use crate::tests_helpers::{assert_json, parse_json, parse_toml, validate_json, LATEST_ABI};
 use crate::Config;
 use landlock::{Access, AccessFs, AccessNet, Scope, ABI};
@@ -498,8 +499,8 @@ fn test_one_path_beneath_str() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute.into(),
             rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
             ..Default::default()
@@ -541,8 +542,8 @@ fn test_dup_path_beneath_1() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute.into(),
             rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
             ..Default::default()
@@ -570,8 +571,8 @@ fn test_dup_path_beneath_2() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute.into(),
             rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
             ..Default::default()
@@ -610,8 +611,8 @@ fn test_overlap_path_beneath() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute | AccessFs::ReadFile | AccessFs::WriteFile,
             rules_path_beneath: [(
                 PathBuf::from("."),
@@ -643,8 +644,8 @@ fn test_normalization_path_beneath() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute.into(),
             rules_path_beneath: [
                 (PathBuf::from("."), AccessFs::Execute.into()),
@@ -1040,8 +1041,8 @@ fn test_infer_handled_access_fs() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute | AccessFs::WriteFile | AccessFs::ReadFile,
             rules_path_beneath: [(PathBuf::from("."), AccessFs::WriteFile | AccessFs::ReadFile)]
                 .into(),
@@ -1086,8 +1087,8 @@ fn test_path_beneath_alone() {
         ]
     }"#;
     assert_eq!(
-        parse_json(json),
-        Ok(Config {
+        parse_json(json).unwrap().resolve(),
+        Ok(ResolvedConfig {
             handled_fs: AccessFs::Execute.into(),
             rules_path_beneath: [(PathBuf::from("."), AccessFs::Execute.into())].into(),
             ..Default::default()

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -38,7 +38,7 @@ impl FromStr for Name {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum NameError {
     #[error("name cannot be empty")]
     Empty,
@@ -48,11 +48,11 @@ pub enum NameError {
     InvalidCharacter(String),
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct Variables(BTreeMap<Name, BTreeSet<String>>);
 
-#[derive(Debug, Error)]
-pub enum ExtrapolateError {
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ResolveError {
     #[error("variable '{0}' not found")]
     VariableNotFound(Name),
     #[error(transparent)]
@@ -65,10 +65,10 @@ impl Variables {
     }
 
     // TODO: Return references instead of cloning.
-    pub(crate) fn extrapolate(
+    pub(crate) fn resolve(
         &self,
         template: &TemplateString,
-    ) -> Result<Vec<BTreeSet<String>>, ExtrapolateError> {
+    ) -> Result<Vec<BTreeSet<String>>, ResolveError> {
         template
             .0
             .iter()
@@ -78,7 +78,7 @@ impl Variables {
                     .0
                     .get(name)
                     .cloned()
-                    .ok_or_else(|| ExtrapolateError::VariableNotFound(name.clone())),
+                    .ok_or_else(|| ResolveError::VariableNotFound(name.clone())),
             })
             .collect()
     }

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -60,8 +60,8 @@ pub enum ResolveError {
 }
 
 impl Variables {
-    pub(crate) fn insert(&mut self, key: Name, values: BTreeSet<String>) {
-        self.0.insert(key, values);
+    pub(crate) fn extend(&mut self, key: Name, values: BTreeSet<String>) {
+        self.0.entry(key).or_default().extend(values);
     }
 
     // TODO: Return references instead of cloning.
@@ -81,6 +81,10 @@ impl Variables {
                     .ok_or_else(|| ResolveError::VariableNotFound(name.clone())),
             })
             .collect()
+    }
+
+    pub(crate) fn iter(&self) -> std::collections::btree_map::Iter<'_, Name, BTreeSet<String>> {
+        self.0.iter()
     }
 
     // Used by tests_parser.rs


### PR DESCRIPTION
Add `Config::compose()` to compose two configurations in a safe way.

Add a new `ResolvedConfig` type for variable resolution.

See #20