### PR TITLE
Fix comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ literal = ["/root", "/home"]
 name = "config"
 literal = ["/etc"]
 
-# Main system directories can be read, including the current path.
+# Main system file hierarchies can be read and executed, including the current path (for test only).
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
 parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
-# Only allow writing to /tmp and /var/tmp .
+# Only allow writing to temporary and home directories.
 [[path_beneath]]
 allowed_access = ["v5.read_write"]
 parent = ["${tmp}", "${home}"]

--- a/examples/micro-var.toml
+++ b/examples/micro-var.toml
@@ -10,12 +10,12 @@ literal = ["/root", "/home"]
 name = "config"
 literal = ["/etc"]
 
-# Main system directories can be read, including the current path.
+# Main system file hierarchies can be read and executed.
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
-parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
+parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
-# Only allow writing to /tmp and /var/tmp .
+# Only allow writing to temporary and home directories.
 [[path_beneath]]
 allowed_access = ["v5.read_write"]
 parent = ["${tmp}", "${home}"]


### PR DESCRIPTION
Update comments for the micro-var example to reflect the current configuration.

Remove the current directory in the README.md because this should only be used for tests.

See #39