### PR TITLE
Switch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ literal = ["/root", "/home"]
 name = "config"
 literal = ["/etc"]
 
-# Main system file hierarchies can be read and executed, including the current path (for test only).
+# Main system file hierarchies can be read and executed.
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
-parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
+parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]

--- a/examples/micro-var.toml
+++ b/examples/micro-var.toml
@@ -10,10 +10,10 @@ literal = ["/root", "/home"]
 name = "config"
 literal = ["/etc"]
 
-# Main system file hierarchies can be read and executed.
+# Main system file hierarchies can be read and executed, including the current path (for test only).
 [[path_beneath]]
 allowed_access = ["v5.read_execute"]
-parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
+parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]


### PR DESCRIPTION
The micro-var test example should be used in the example config file, not the README.md file.

Fix #41 