### PR TITLE
Improve variable implementation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ impl TryFrom<NonEmptyStruct<JsonConfig>> for Config {
             let name = variable.name.parse()?;
             let literal = variable.literal.unwrap_or_default();
             // TODO: Check and warn if users tried to use variable in literal strings?
-            config.variables.extend(name, literal.into_iter().collect());
+            config.variables.extend(name, literal);
         }
 
         for ruleset in json.ruleset.unwrap_or_default() {

--- a/src/tests_variable.rs
+++ b/src/tests_variable.rs
@@ -50,7 +50,7 @@ fn test_without_value() {
             }
         ]
     }"#;
-    let empty: &[&str] = &[];
+    let empty: &[String] = &[];
     assert_eq!(
         parse_json(json),
         Ok(Config {


### PR DESCRIPTION
Only walk one time the variable name.

Make Variables::extend() generic and simplify callers.