### PR TITLE
Use abi.* synthetic variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Sandboxer library leveraging Landlock with JSON or TOML configuration"
 
 [workspace.dependencies]
-landlock = "0.4.2"
+landlock = "0.4.3"
 
 [package]
 name = "landlockconfig"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ variables, access right groups, and list of directory hierarchies for
 conciseness.
 
 ```toml
+abi = 6
+
 [[variable]]
 name = "tmp"
 literal = ["/tmp", "/var/tmp"]
@@ -148,12 +150,12 @@ literal = ["/etc"]
 
 # Main system file hierarchies can be read and executed.
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${tmp}", "${home}"]
 ```
 

--- a/examples/micro-var.toml
+++ b/examples/micro-var.toml
@@ -1,3 +1,5 @@
+abi = 5
+
 [[variable]]
 name = "tmp"
 literal = ["/tmp", "/var/tmp"]
@@ -12,10 +14,10 @@ literal = ["/etc"]
 
 # Main system file hierarchies can be read and executed, including the current path (for test only).
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = [".", "/bin", "/lib", "/usr", "/dev", "/proc", "${config}"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${tmp}", "${home}"]

--- a/examples/micro-write-tmp.toml
+++ b/examples/micro-write-tmp.toml
@@ -1,17 +1,19 @@
+abi = 5
+
 # Infered properties:
 # [[ruleset]]
-# handled_access_fs = ["v5.all"]
+# handled_access_fs = ["abi.all"]
 # handled_access_net = ["bind_tcp"]
 #
-# We need to be careful to cover all access rights (e.g. v5.read_execute +
-# v5.read_write = v5.all), otherwise the missing accesses would not be denied.
+# We need to be careful to cover all access rights (e.g. abi.read_execute +
+# abi.read_write = abi.all), otherwise the missing accesses would not be denied.
 
 # Main system directories can be red.
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]
 
 # Only allow writing to /tmp.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["/tmp"]

--- a/examples/mini-scoped.json
+++ b/examples/mini-scoped.json
@@ -1,11 +1,12 @@
 {
+  "abi": 6,
   "ruleset": [
     {
       "handledAccessNet": [
-        "v6.all"
+        "abi.all"
       ],
       "scoped": [
-        "v6.all"
+        "abi.all"
       ]
     }
   ]

--- a/examples/mini-write-tmp.json
+++ b/examples/mini-write-tmp.json
@@ -1,8 +1,9 @@
 {
+  "abi": 5,
   "ruleset": [
     {
       "handledAccessFs": [
-        "v5.all"
+        "abi.all"
       ],
       "handledAccessNet": [
         "bind_tcp"
@@ -12,7 +13,7 @@
   "pathBeneath": [
     {
       "allowedAccess": [
-        "v5.read_execute"
+        "abi.read_execute"
       ],
       "parent": [
         ".",
@@ -26,7 +27,7 @@
     },
     {
       "allowedAccess": [
-        "v5.read_write"
+        "abi.read_write"
       ],
       "parent": [
         "/tmp"

--- a/examples/mini-write-tmp.toml
+++ b/examples/mini-write-tmp.toml
@@ -1,15 +1,17 @@
+abi = 5
+
 [[ruleset]]
-handled_access_fs = ["v5.all"]
+handled_access_fs = ["abi.all"]
 handled_access_net = ["bind_tcp"]
 
 # Main system directories can be red.
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = [".", "/bin", "/lib", "/usr", "/dev", "/etc", "/proc",]
 
 # Only allow writing to /tmp.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["/tmp"]
 
 # Only web ports are allowed.

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -32,27 +32,9 @@
         "make_fifo",
         "make_block",
         "make_sym",
-        "v1.all",
-        "v1.read_execute",
-        "v1.read_write",
         "refer",
-        "v2.all",
-        "v2.read_execute",
-        "v2.read_write",
         "truncate",
-        "v3.all",
-        "v3.read_execute",
-        "v3.read_write",
-        "v4.all",
-        "v4.read_execute",
-        "v4.read_write",
-        "ioctl_dev",
-        "v5.all",
-        "v5.read_execute",
-        "v5.read_write",
-        "v6.all",
-        "v6.read_execute",
-        "v6.read_write"
+        "ioctl_dev"
       ]
     },
     "accessNet": {
@@ -60,10 +42,7 @@
       "enum": [
         "abi.all",
         "bind_tcp",
-        "connect_tcp",
-        "v4.all",
-        "v5.all",
-        "v6.all"
+        "connect_tcp"
       ]
     },
     "scope": {
@@ -71,8 +50,7 @@
       "enum": [
         "abi.all",
         "abstract_unix_socket",
-        "signal",
-        "v6.all"
+        "signal"
       ]
     }
   },

--- a/schema/landlockconfig.json
+++ b/schema/landlockconfig.json
@@ -8,9 +8,17 @@
       "minimum": 0,
       "maximum": 18446744073709551615
     },
+    "abi": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2147483647
+    },
     "accessFs": {
       "type": "string",
       "enum": [
+        "abi.all",
+        "abi.read_execute",
+        "abi.read_write",
         "execute",
         "write_file",
         "read_file",
@@ -50,6 +58,7 @@
     "accessNet": {
       "type": "string",
       "enum": [
+        "abi.all",
         "bind_tcp",
         "connect_tcp",
         "v4.all",
@@ -60,6 +69,7 @@
     "scope": {
       "type": "string",
       "enum": [
+        "abi.all",
         "abstract_unix_socket",
         "signal",
         "v6.all"
@@ -67,6 +77,9 @@
     }
   },
   "properties": {
+    "abi": {
+      "$ref": "#/definitions/abi"
+    },
     "variable": {
       "type": "array",
       "minItems": 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,6 @@ mod tests_variable;
 
 #[cfg(test)]
 mod tests_compose;
+
+#[cfg(test)]
+mod tests_abi;

--- a/src/tests_abi.rs
+++ b/src/tests_abi.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    parser::TemplateString,
+    tests_helpers::{parse_json, parse_json_schema, parse_toml, LATEST_ABI},
+    Config,
+};
+use landlock::{Access, AccessFs, AccessNet, Scope, ABI};
+use serde_json::error::Category;
+
+#[test]
+fn test_access_fs_with_value() {
+    let json = r#"{
+        "abi": 2,
+        "ruleset": [
+            {
+                "handledAccessFs": [
+                    "abi.all"
+                    ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 2
+        [[ruleset]]
+        handled_access_fs = [
+            "abi.all",
+        ]
+    "#;
+
+    let config = Config {
+        abi: Some(ABI::V2),
+        handled_fs: AccessFs::from_all(ABI::V2),
+        ..Default::default()
+    };
+    assert_eq!(parse_json(json).unwrap(), config);
+    assert_eq!(parse_toml(toml).unwrap(), config);
+}
+
+#[test]
+fn test_access_fs_without_value() {
+    let json = r#"{
+        "ruleset": [
+            {
+                "handledAccessFs": [
+                    "abi.all"
+                    ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        [[ruleset]]
+        handled_access_fs = [
+            "abi.all",
+        ]
+    "#;
+
+    assert_eq!(parse_json_schema(json, false), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_format_error() {
+    let json = r#"{
+        "abi": 1
+    }"#;
+    let toml = r#"
+        abi = 1
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_format_ok() {
+    let json = r#"{
+        "abi": 1,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 1
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    let config = Config {
+        abi: Some(ABI::V1),
+        handled_fs: AccessFs::Execute.into(),
+        ..Default::default()
+    };
+    assert_eq!(parse_json(json).unwrap(), config);
+    assert_eq!(parse_toml(toml).unwrap(), config);
+}
+
+#[test]
+fn test_dup_abi() {
+    let json = r#"{
+        "abi": 1,
+        "abi": 1,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 1
+        abi = 1
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    // Test that duplicate 'abi' fields are rejected by the parser.  Uses
+    // parse_json_schema(json, false) because duplicate field rejection is a
+    // parser-level concern, not schema-level (JSON schema assumes valid JSON).
+    assert_eq!(parse_json_schema(json, false), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_all_versions_abi_all() {
+    for version in 1..=(LATEST_ABI as i32) {
+        let json = format!(
+            r#"{{
+                "abi": {},
+                "ruleset": [
+                    {{
+                        "handledAccessFs": [ "abi.all" ],
+                        "handledAccessNet": [ "abi.all" ],
+                        "scoped": [ "abi.all" ]
+                    }}
+                ],
+                "pathBeneath": [
+                    {{
+                        "allowedAccess": [ "abi.all" ],
+                        "parent": [ "." ]
+                    }}
+                ],
+                "netPort": [
+                    {{
+                        "allowedAccess": [ "abi.all" ],
+                        "port": [ 1 ]
+                    }}
+                ]
+            }}"#,
+            version
+        );
+        let toml = format!(
+            r#"
+            abi = {}
+            [[ruleset]]
+            handled_access_fs = [ "abi.all" ]
+            handled_access_net = [ "abi.all" ]
+            scoped = [ "abi.all" ]
+            [[path_beneath]]
+            allowed_access = [ "abi.all" ]
+            parent = [ "." ]
+            [[net_port]]
+            allowed_access = [ "abi.all" ]
+            port = [ 1 ]
+            "#,
+            version
+        );
+
+        let abi = version.into();
+        let mut config = Config {
+            abi: Some(abi),
+            handled_fs: AccessFs::from_all(abi),
+            handled_net: AccessNet::from_all(abi),
+            scoped: Scope::from_all(abi),
+            rules_path_beneath: [(TemplateString::from_text("."), AccessFs::from_all(abi))].into(),
+            ..Default::default()
+        };
+        if abi >= ABI::V4 {
+            // Do not add rules with empty access right.
+            config.rules_net_port = [(1, AccessNet::from_all(abi))].into();
+        }
+        println!("Testing ABI {version} and expecting {config:?}");
+        assert_eq!(parse_json(&json).unwrap(), config);
+        assert_eq!(parse_toml(&toml).unwrap(), config);
+    }
+}
+
+#[test]
+fn test_all_versions_abi_read_execute() {
+    for version in 1..=(LATEST_ABI as i32) {
+        let json = format!(
+            r#"{{
+                "abi": {},
+                "ruleset": [
+                    {{
+                        "handledAccessFs": [ "abi.read_execute" ]
+                    }}
+                ],
+                "pathBeneath": [
+                    {{
+                        "allowedAccess": [ "abi.read_execute" ],
+                        "parent": [ "." ]
+                    }}
+                ]
+            }}"#,
+            version
+        );
+        let toml = format!(
+            r#"
+            abi = {}
+            [[ruleset]]
+            handled_access_fs = [ "abi.read_execute" ]
+            [[path_beneath]]
+            allowed_access = [ "abi.read_execute" ]
+            parent = [ "." ]
+            "#,
+            version
+        );
+
+        let abi = version.into();
+        let expected_access =
+            AccessFs::from_read(abi) | (AccessFs::from_all(abi) & AccessFs::Refer);
+
+        let config = Config {
+            abi: Some(abi),
+            handled_fs: expected_access,
+            rules_path_beneath: [(TemplateString::from_text("."), expected_access)].into(),
+            ..Default::default()
+        };
+        println!("Testing ABI {version} read_execute and expecting {config:?}");
+        assert_eq!(parse_json(&json).unwrap(), config);
+        assert_eq!(parse_toml(&toml).unwrap(), config);
+    }
+}
+
+#[test]
+fn test_all_versions_abi_read_write() {
+    for version in 1..=(LATEST_ABI as i32) {
+        let json = format!(
+            r#"{{
+                "abi": {},
+                "ruleset": [
+                    {{
+                        "handledAccessFs": [ "abi.read_write" ]
+                    }}
+                ],
+                "pathBeneath": [
+                    {{
+                        "allowedAccess": [ "abi.read_write" ],
+                        "parent": [ "." ]
+                    }}
+                ]
+            }}"#,
+            version
+        );
+        let toml = format!(
+            r#"
+            abi = {}
+            [[ruleset]]
+            handled_access_fs = [ "abi.read_write" ]
+            [[path_beneath]]
+            allowed_access = [ "abi.read_write" ]
+            parent = [ "." ]
+            "#,
+            version
+        );
+
+        let abi = version.into();
+        let expected_access = AccessFs::from_all(abi) & !AccessFs::Execute;
+
+        let config = Config {
+            abi: Some(abi),
+            handled_fs: expected_access,
+            rules_path_beneath: [(TemplateString::from_text("."), expected_access)].into(),
+            ..Default::default()
+        };
+        println!("Testing ABI {version} read_write and expecting {config:?}");
+        assert_eq!(parse_json(&json).unwrap(), config);
+        assert_eq!(parse_toml(&toml).unwrap(), config);
+    }
+}
+
+#[test]
+fn test_zero() {
+    let json = r#"{
+        "abi": 0,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 0
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_negative() {
+    let json = r#"{
+        "abi": -1,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = -1
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_i32() {
+    // 2^31 - 1
+    let json = r#"{
+        "abi": 2147483647,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "abi.all" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 2147483647
+        [[ruleset]]
+        handled_access_fs = [
+            "abi.all",
+        ]
+    "#;
+
+    let abi = ABI::from(2147483647);
+    // To not require perfect syncing between this crate and the Landlock crate,
+    // only check that the returned ABI is greater than or equal to the
+    // currently greatest ABI.
+    assert!(abi >= LATEST_ABI);
+    let config = Config {
+        abi: Some(abi),
+        handled_fs: AccessFs::from_all(abi),
+        ..Default::default()
+    };
+    assert_eq!(parse_json(json).unwrap(), config);
+    assert_eq!(parse_toml(toml).unwrap(), config);
+}
+
+#[test]
+fn test_p31() {
+    // 2^31
+    let json = r#"{
+        "abi": 2147483648,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "abi.all" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 2147483648
+        [[ruleset]]
+        handled_access_fs = [
+            "abi.all",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_p32() {
+    // 2^32
+    let json = r#"{
+        "abi": 4294967295,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 4294967295
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_p64() {
+    // 2^64
+    let json = r#"{
+        "abi": 18446744073709551616,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 18446744073709551616
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}
+
+#[test]
+fn test_p128() {
+    // 2^128
+    let json = r#"{
+        "abi": 340282366920938463463374607431768211456,
+        "ruleset": [
+            {
+                "handledAccessFs": [ "execute" ]
+            }
+        ]
+    }"#;
+    let toml = r#"
+        abi = 340282366920938463463374607431768211456
+        [[ruleset]]
+        handled_access_fs = [
+            "execute",
+        ]
+    "#;
+
+    assert_eq!(parse_json(json), Err(Category::Data));
+    assert!(parse_toml(toml).is_err());
+}

--- a/src/tests_compose.rs
+++ b/src/tests_compose.rs
@@ -34,24 +34,26 @@ fn get_composition(json1: &str, json2: &str) -> ResolvedConfig {
 #[test]
 fn test_compose_most_fs_net() {
     let json1 = r#"{
+        "abi": 4,
         "ruleset": [
             {
-                "handledAccessFs": [ "v4.all" ],
-                "handledAccessNet": [ "v4.all" ],
-                "scoped": [ "v6.all" ]
+                "handledAccessFs": [ "abi.all" ],
+                "handledAccessNet": [ "abi.all" ],
+                "scoped": [ "abi.all" ]
             }
         ]
     }"#;
     let json2 = r#"{
+        "abi": 6,
         "pathBeneath": [
             {
-                "allowedAccess": [ "v6.all" ],
+                "allowedAccess": [ "abi.all" ],
                 "parent": [ "a" ]
             }
         ],
         "netPort": [
             {
-                "allowedAccess": [ "v6.all" ],
+                "allowedAccess": [ "abi.all" ],
                 "port": [ 1 ]
             }
         ]
@@ -79,9 +81,10 @@ fn test_compose_scope() {
         ]
     }"#;
     let json2 = r#"{
+        "abi": 6,
         "ruleset": [
             {
-                "scoped": [ "v6.all" ]
+                "scoped": [ "abi.all" ]
             }
         ]
     }"#;

--- a/src/tests_helpers.rs
+++ b/src/tests_helpers.rs
@@ -31,10 +31,6 @@ pub(crate) fn validate_json(json: &str) -> Result<(), ()> {
     })
 }
 
-pub(crate) fn assert_json(data: &str, ret: Result<(), Category>) {
-    assert_eq!(parse_json(data).map(|_| ()), ret);
-}
-
 // TODO: Return ParseJsonError
 pub(crate) fn parse_json_schema(json: &str, with_schema: bool) -> Result<Config, Category> {
     let cursor = std::io::Cursor::new(json);

--- a/tests/composition/README.md
+++ b/tests/composition/README.md
@@ -3,52 +3,58 @@
 ## [TOML source #1](source/s1.toml)
 
 ```toml
+abi = 5
+
 [[variable]]
 name = "rw"
 literal = ["/tmp", "/var/tmp"]
 
 # Main system file hierarchies can be read and executed.
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "/etc"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${rw}"]
 ```
 
 ## [TOML source #2](source/s2.toml)
 
 ```toml
+abi = 4
+
 [[variable]]
 name = "rw"
 literal = ["/home/user/tmp"]
 
 [[ruleset]]
-handled_access_fs = ["v4.all"]
+handled_access_fs = ["abi.all"]
 
 # Custom apps.
 [[path_beneath]]
-allowed_access = ["v4.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/home/user/bin"]
 ```
 
 ## [TOML composition](s.toml)
 
 ```toml
+abi = 4
+
 [[variable]]
 name = "rw"
 literal = ["/tmp", "/var/tmp", "/home/user/tmp"]
 
 # Main system file hierarchies can be read and executed.
 [[path_beneath]]
-allowed_access = ["v4.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "/etc", "/home/user/bin"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v4.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${rw}"]
 ```
 
@@ -56,6 +62,7 @@ parent = ["${rw}"]
 
 ```json
 {
+  "abi": 4,
   "variable": [
     {
       "name": "rw",
@@ -69,7 +76,7 @@ parent = ["${rw}"]
   "pathBeneath": [
     {
       "allowedAccess": [
-        "v4.read_execute"
+        "abi.read_execute"
       ],
       "parent": [
         "/bin",
@@ -83,7 +90,7 @@ parent = ["${rw}"]
     },
     {
       "allowedAccess": [
-        "v4.read_write"
+        "abi.read_write"
       ],
       "parent": [
         "${rw}"

--- a/tests/composition/s.json
+++ b/tests/composition/s.json
@@ -1,4 +1,5 @@
 {
+  "abi": 4,
   "variable": [
     {
       "name": "rw",
@@ -12,7 +13,7 @@
   "pathBeneath": [
     {
       "allowedAccess": [
-        "v4.read_execute"
+        "abi.read_execute"
       ],
       "parent": [
         "/bin",
@@ -26,7 +27,7 @@
     },
     {
       "allowedAccess": [
-        "v4.read_write"
+        "abi.read_write"
       ],
       "parent": [
         "${rw}"

--- a/tests/composition/s.toml
+++ b/tests/composition/s.toml
@@ -1,13 +1,15 @@
+abi = 4
+
 [[variable]]
 name = "rw"
 literal = ["/tmp", "/var/tmp", "/home/user/tmp"]
 
 # Main system file hierarchies can be read and executed.
 [[path_beneath]]
-allowed_access = ["v4.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "/etc", "/home/user/bin"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v4.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${rw}"]

--- a/tests/composition/source/s1.toml
+++ b/tests/composition/source/s1.toml
@@ -1,13 +1,15 @@
+abi = 5
+
 [[variable]]
 name = "rw"
 literal = ["/tmp", "/var/tmp"]
 
 # Main system file hierarchies can be read and executed.
 [[path_beneath]]
-allowed_access = ["v5.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/bin", "/lib", "/usr", "/dev", "/proc", "/etc"]
 
 # Only allow writing to temporary and home directories.
 [[path_beneath]]
-allowed_access = ["v5.read_write"]
+allowed_access = ["abi.read_write"]
 parent = ["${rw}"]

--- a/tests/composition/source/s2.toml
+++ b/tests/composition/source/s2.toml
@@ -1,11 +1,13 @@
+abi = 4
+
 [[variable]]
 name = "rw"
 literal = ["/home/user/tmp"]
 
 [[ruleset]]
-handled_access_fs = ["v4.all"]
+handled_access_fs = ["abi.all"]
 
 # Custom apps.
 [[path_beneath]]
-allowed_access = ["v4.read_execute"]
+allowed_access = ["abi.read_execute"]
 parent = ["/home/user/bin"]


### PR DESCRIPTION
In preparation to replace the "vN." prefixes with a global max ABI version.  This new approach is flexible enough and simpler.

This is now possible thanks to the composition feature (each file can have a dedicated max ABI) and its similar to the use of a local variable.

The variable `abi = 4` is the highest version of the Landlock ABI, which should replace the hardcoded v4 uses.  This is convenient to update configurations to newest Landlock features by only updating one line instead of all use of vN.

Example:
```toml
abi = 4

[[ruleset]]
handled_access_fs = ["abi.all"]

[[path_beneath]]
allowed_access = ["abi.read_execute"]
parent = ["/usr"]
```

Depends on https://github.com/landlock-lsm/rust-landlock/pull/108