### PR TITLE
Build  Arch Linux package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
     - name: Install cargo-c
       run: sudo apt install cargo-c
 
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+        key: cargo-registry
+
     - uses: actions/checkout@v4
       with:
         ref: ${{ matrix.commit }}
@@ -98,7 +105,7 @@ jobs:
       with:
         path: |
           target
-          ~/.cargo
+          ~/.cargo/bin
           ~/.rustup
         key: rust-msrv
         restore-keys: |
@@ -141,6 +148,13 @@ jobs:
     - name: Install cargo-c
       run: sudo apt install cargo-c
 
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+        key: cargo-registry
+
     - uses: actions/checkout@v4
       with:
         ref: ${{ matrix.commit }}
@@ -150,7 +164,7 @@ jobs:
       with:
         path: |
           target
-          ~/.cargo
+          ~/.cargo/bin
           ~/.rustup
         key: rust-stable
         restore-keys: |
@@ -222,3 +236,59 @@ jobs:
 
     - name: Test C example
       run: make -C c/examples test
+
+  archlinux_package:
+    runs-on: ubuntu-24.04
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
+    steps:
+
+    - uses: docker/setup-buildx-action@v3
+
+    - name: Get user IDs
+      id: ids
+      run: |
+        echo "uid=$(id -u)" >> $GITHUB_OUTPUT
+        echo "gid=$(id -g)" >> $GITHUB_OUTPUT
+
+    - name: Build Arch Linux container
+      uses: docker/build-push-action@v5
+      with:
+        file: pkg/arch/Dockerfile
+        build-args: |
+          UID=${{ steps.ids.outputs.uid }}
+          GID=${{ steps.ids.outputs.gid }}
+        tags: landlockconfig-archlinux
+        cache-from: type=gha
+        cache-to: type=gha,mode=min
+        load: true
+
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+        key: cargo-registry
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.commit }}
+
+    - name: Cache build for Arch Linux
+      uses: actions/cache@v4
+      with:
+        path: |
+          target
+        key: rust-archlinux
+        restore-keys: |
+          rust-
+
+    - name: Build and install Arch Linux package
+      run: |
+        docker run --rm \
+          --volume "$HOME/.cargo/registry:/home/builder/.cargo/registry" \
+          --volume "$PWD:/landlockconfig" \
+          landlockconfig-archlinux

--- a/pkg/arch/.gitignore
+++ b/pkg/arch/.gitignore
@@ -1,0 +1,3 @@
+/landlockconfig-*.pkg.tar.zst
+/pkg
+/src

--- a/pkg/arch/Dockerfile
+++ b/pkg/arch/Dockerfile
@@ -1,0 +1,26 @@
+# See docker-build.sh
+
+FROM archlinux
+
+ARG UID=1000
+ARG GID=1000
+
+RUN pacman -Syu --noconfirm \
+        binutils \
+        cargo-c \
+        fakeroot \
+        gcc \
+        git \
+        make \
+        pkg-config \
+        rust \
+        sudo \
+        && \
+    pacman -Scc --noconfirm && \
+    groupadd -g "${GID}" builder && \
+    useradd -m -u "${UID}" -g "${GID}" builder && \
+    echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER builder
+WORKDIR /landlockconfig
+CMD ["make", "-C", "pkg/arch", "install"]

--- a/pkg/arch/Makefile
+++ b/pkg/arch/Makefile
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+.PHONY: build clean docker
+
+# Build package directly (requires Arch Linux).
+build:
+	makepkg --force
+	sed -i -e 's/^pkgver=.*/pkgver=0/' PKGBUILD
+
+install: build
+	sudo pacman -U --noconfirm -- "$$(ls -t landlockconfig-git-*.pkg.tar.zst | head -n 1)"
+
+# Build package using Docker container
+# Prerequisites: Install rustup and cargo-c (see .github/workflows/ci.yml)
+docker:
+	docker buildx build --file Dockerfile \
+		--build-arg "UID=$(shell id -u)" \
+		--build-arg "GID=$(shell id -g)" \
+		--tag landlockconfig-archlinux \
+		.
+	docker run --rm \
+		--volume "$(HOME)/.cargo/registry:/home/builder/.cargo/registry:ro" \
+		--volume "$(CURDIR)/../..:/landlockconfig" \
+		landlockconfig-archlinux
+
+clean:
+	rm landlockconfig-git-*.pkg.tar.zst || :

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Mickaël Salaün
+#
+# For now, this package is only meant to be used for testing with the Landlock
+# Config repository.
+# TODO: Make it more generic while still efficient for development and CI (see
+# https://gitlab.archlinux.org/archlinux/packaging/packages/systemd/-/commit/16294a0b4415b15f48e07f9e939c49fdf069c506).
+
+pkgname=landlockconfig-git
+pkgver=0
+pkgrel=1
+pkgdesc="Sandboxer library leveraging Landlock with JSON or TOML configuration (git version)"
+arch=('x86_64' 'aarch64')
+url="https://landlock.io"
+license=('MIT' 'Apache-2.0')
+depends=('glibc' 'gcc-libs')
+makedepends=('cargo' 'cargo-c' 'git' 'rust')
+provides=('landlockconfig' 'liblandlockconfig.so')
+conflicts=('landlockconfig')
+
+# Disable debug package creation to avoid debug symlink issues.
+options=('!debug')
+
+# Build directly from the current repository.
+# Change this to remote URL for distribution: git+https://github.com/landlock-lsm/landlockconfig.git
+source=()
+sha256sums=()
+
+pkgver() {
+    cd "$startdir/../.."
+
+    local crate_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)
+    local rev_count=$(git rev-list --count HEAD)
+    local short_hash=$(git rev-parse --short HEAD)
+    printf "%s.r%s.%s" "$crate_version" "$rev_count" "$short_hash"
+}
+
+build() {
+    # Work directly with the current repository and reuse cached target directory.
+    cd "$startdir/../.."
+
+    cargo cbuild --package=landlockconfig_ffi --release
+}
+
+check() {
+    cd "$startdir/../.."
+
+    cargo test
+}
+
+package() {
+    cd "$startdir/../.."
+
+    cargo cinstall --package=landlockconfig_ffi --release \
+        --prefix=/usr --destdir="$pkgdir"
+
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+    install -Dm644 COPYRIGHT "$pkgdir/usr/share/doc/$pkgname/COPYRIGHT"
+
+    install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
+    install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
+}

--- a/pkg/arch/README.md
+++ b/pkg/arch/README.md
@@ -1,0 +1,29 @@
+# Arch Linux package
+
+This directory contains files for building an Arch Linux package of Landlock Config.
+
+Built packages are only [meant for development and testing](https://github.com/landlock-lsm/landlockconfig/pull/52).
+
+## Building the package
+
+### Option 1: using Docker
+
+On any Linux system with Docker installed:
+
+```bash
+make docker
+```
+
+### Option 2: native build
+
+On Arch Linux systems with development tools installed:
+
+```bash
+make build
+```
+
+## Output
+
+The build creates a package file: `landlockconfig-git-*.pkg.tar.zst`
+
+Install with: `sudo pacman -U landlockconfig-git-*.pkg.tar.zst`


### PR DESCRIPTION
Add Makefile to build a package from this repository while reusing build artifacts (e.g. to speed up build and CI).

Improve FFI error types.

See #18

Cc @Foxboron