### PR TITLE
Fix GitHub CI for Arch Linux container

### DIFF
--- a/pkg/arch/Dockerfile
+++ b/pkg/arch/Dockerfile
@@ -22,5 +22,6 @@ RUN pacman -Syu --noconfirm \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 USER builder
+RUN mkdir -p ~/.cargo/registry
 WORKDIR /landlockconfig
 CMD ["make", "-C", "pkg/arch", "install"]

--- a/pkg/arch/Makefile
+++ b/pkg/arch/Makefile
@@ -8,7 +8,7 @@ build:
 	sed -i -e 's/^pkgver=.*/pkgver=0/' PKGBUILD
 
 install: build
-	sudo pacman -U --noconfirm -- "$$(ls -t landlockconfig-git-*.pkg.tar.zst | head -n 1)"
+	sudo pacman -U --noconfirm -- "$$(ls -1t landlockconfig-git-*.pkg.tar.zst | head -n 1)"
 
 # Build package using Docker container
 # Prerequisites: Install rustup and cargo-c (see .github/workflows/ci.yml)


### PR DESCRIPTION
With an empty cache (i.e. no key found), ~/.cargo/registry is created with wrong access rights, which makes the package build failed.

Create ~/.cargo/registry in the container to make sure it always works.

See
* https://github.com/landlock-lsm/landlockconfig/actions/runs/18449312651/job/52560615537
* #52 