### PR TITLE
Export useful types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub use config::{BuildRulesetError, Config, ConfigFormat, OptionalConfig, RuleError};
+pub use config::{
+    BuildRulesetError, Config, ConfigFormat, OptionalConfig, ParseDirectoryError, ResolvedConfig,
+    RuleError,
+};
+pub use variable::ResolveError;
 
 mod config;
 mod nonempty;


### PR DESCRIPTION
Export error and other already-public types: ParseDirectoryError, ResolvedConfig, ResolveError.