### PR TITLE
Fix CI because of dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["ffi"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.83"
 license = "MIT OR Apache-2.0"
 description = "Sandboxer library leveraging Landlock with JSON or TOML configuration"
 


### PR DESCRIPTION
MSRV needs a bump because of jsonchema/icu, and other [CI fixes are needed](https://github.com/landlock-lsm/landlockconfig/actions/runs/19762402774/job/56627143759).