### PR TITLE
Bump MSRV to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
     - name: Check JSON compose
       run: ./schema/check.sh tests/composition/s.json
 
-  ubuntu_24_rust_msrv:
-    runs-on: ubuntu-24.04
+  ubuntu_26_rust_msrv:
+    runs-on: ubuntu-26.04
     needs: commit_list
     strategy:
       fail-fast: false
@@ -136,8 +136,8 @@ jobs:
     - name: Build FFI
       run: rustup run ${{ env.RUST_TOOLCHAIN }} cargo cinstall --package=landlockconfig_ffi --destdir=out
 
-  ubuntu_24_rust_stable:
-    runs-on: ubuntu-24.04
+  ubuntu_26_rust_stable:
+    runs-on: ubuntu-26.04
     needs: commit_list
     strategy:
       fail-fast: false
@@ -288,6 +288,9 @@ jobs:
 
     - name: Build and install Arch Linux package
       run: |
+        # Create the registry on the host so the bind mount below is owned
+        # by the runner user instead of root (cache miss leaves it absent).
+        mkdir -p "$HOME/.cargo/registry"
         docker run --rm \
           --volume "$HOME/.cargo/registry:/home/builder/.cargo/registry" \
           --volume "$PWD:/landlockconfig" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["ffi"]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 description = "Sandboxer library leveraging Landlock with JSON or TOML configuration"
 

--- a/c/examples/Makefile
+++ b/c/examples/Makefile
@@ -5,16 +5,17 @@ SOURCE = sandboxer.c
 OBJECT = $(SOURCE:.c=.o)
 
 OUT_DIR = out
-LIB_DIR = $(OUT_DIR)/lib
 
 PKG_NAME = landlockconfig
-PKG_CONFIG_PATH := $(LIB_DIR)/pkgconfig
+# cargo cinstall may install into a multiarch libdir (e.g.
+# lib/x86_64-linux-gnu), so locate the generated pkg-config file and let
+# pkg-config provide the paths instead of assuming a fixed layout.
+PKG_CONFIG = PKG_CONFIG_PATH="$(shell find $(OUT_DIR) -type d -name pkgconfig)" pkg-config
 
 CC = gcc
-CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKG_NAME)) \
-	-Wall -Werror
-LDFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKG_NAME)) \
-	-L$(LIB_DIR) -Wl,--gc-sections
+CFLAGS = $(shell $(PKG_CONFIG) --cflags $(PKG_NAME)) -Wall -Werror
+LDFLAGS = $(shell $(PKG_CONFIG) --libs $(PKG_NAME)) -Wl,--gc-sections
+LIB_DIR = $(shell $(PKG_CONFIG) --variable=libdir $(PKG_NAME))
 
 .PHONY: all clean mrproper run FORCE
 


### PR DESCRIPTION
Transitive dependencies (e.g. jsonchema/icu, indexmap) now ship manifests using the 2024 edition, which requires Cargo 1.85 .  Building with an older toolchain fails while parsing the dependency manifests:

  this version of Cargo is older than the `2024` edition, and only
  supports `2015`, `2018`, and `2021` editions.

Raise the minimum supported Rust version from 1.82 to 1.85.  Debian 13 (Trixie) ships rustc 1.85, so this stays within a widely available toolchain:

  https://packages.debian.org/search?keywords=rustc

Also, fix all other issues related to the CI: https://github.com/landlock-lsm/landlockconfig/actions/runs/28407857621