### PR TITLE
ffi: Disable rustdoc for the ffi lib to avoid a doc collision

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "staticlib"]
 name = "landlockconfig"
+doc = false
 
 [dependencies]
 landlock.workspace = true


### PR DESCRIPTION
The ffi crate's library carries the C ABI name, which is identical to the main landlockconfig library name. Documenting the whole workspace therefore fails with an output filename collision, because both libraries would write their rustdoc output to the same path.

The ffi crate's public surface is its generated C header, not rustdoc, so excluding it from documentation resolves the collision without losing anything.