### PR TITLE
Fix clippy warning

### DIFF
--- a/src/variable.rs
+++ b/src/variable.rs
@@ -176,11 +176,7 @@ where
         let mut ret = vec![];
         let mut carry = true;
         for set in self.vec.iter_mut().rev() {
-            if let Some(value) = set.iter.peek() {
-                ret.push((*value).as_ref());
-            } else {
-                return None;
-            }
+            ret.push((*set.iter.peek()?).as_ref());
             if carry {
                 set.iter.next();
                 if set.iter.peek().is_some() {


### PR DESCRIPTION
See https://github.com/landlock-lsm/landlockconfig/actions/runs/29050354312/job/87334195078?pr=67

```
  warning: this block may be rewritten with the `?` operator
     --> src/variable.rs:179:13
      |
  179 | /             if let Some(value) = set.iter.peek() {
  180 | |                 ret.push((*value).as_ref());
  181 | |             } else {
  182 | |                 return None;
  183 | |             }
      | |_____________^
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#question_mark
      = note: `#[warn(clippy::question_mark)]` on by default
  help: replace it with
      |
  179 ~             {
  180 +                 let value = set.iter.peek()?;
  181 +                 ret.push((*value).as_ref());
  182 +             }
      |
```