### PR TITLE
Add a Nix build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,30 @@ jobs:
     - name: Test C example
       run: make -C c/examples test
 
+  nix_derivation:
+    runs-on: ubuntu-24.04
+    needs: commit_list
+    strategy:
+      fail-fast: false
+      matrix:
+        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.commit }}
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build nix derivations
+        run: |
+          make -C pkg/nix
+
+      - name: Run nix tests
+        run: |
+          make -C pkg/nix test
+
   archlinux_package:
     runs-on: ubuntu-24.04
     needs: commit_list

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+result
+result-*

--- a/llconfig/build.rs
+++ b/llconfig/build.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-fn run_git(args: &[&str]) -> String {
+fn run_git(env: &str, args: &[&str]) -> String {
     // A one-off git invocation is simpler than pulling in a crate for this.
     Command::new("git")
         .args(args)
@@ -17,24 +17,28 @@ fn run_git(args: &[&str]) -> String {
                 .collect()
         })
         .filter(|s: &String| !s.is_empty())
+        .or_else(|| std::env::var(env).ok())
         .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn main() {
     println!(
         "cargo:rustc-env=GIT_COMMIT={}",
-        run_git(&[
-            "describe",
-            "--always",
-            // Do not rely on local configuration (i.e. core.abbrev) for length.
-            "--abbrev=12",
-            "--exclude=*",
-            "--dirty",
-        ])
+        run_git(
+            "GIT_COMMIT",
+            &[
+                "describe",
+                "--always",
+                // Do not rely on local configuration (i.e. core.abbrev) for length.
+                "--abbrev=12",
+                "--exclude=*",
+                "--dirty",
+            ]
+        )
     );
 
     println!(
         "cargo:rustc-env=GIT_DATE={}",
-        run_git(&["log", "--max-count=1", "--format=%cs"])
+        run_git("GIT_DATE", &["log", "--max-count=1", "--format=%cs"])
     );
 }

--- a/pkg/nix/.gitignore
+++ b/pkg/nix/.gitignore
@@ -1,0 +1,2 @@
+/llconfig
+/landlockconfig

--- a/pkg/nix/Makefile
+++ b/pkg/nix/Makefile
@@ -1,0 +1,14 @@
+NIX_BUILD = nix-build
+
+.PHONY: landlockconfig llconfig
+
+all: landlockconfig llconfig
+
+landlockconfig:
+	$(NIX_BUILD) --attr landlockconfig --out-link $@
+
+llconfig:
+	$(NIX_BUILD) --attr llconfig --out-link $@
+
+test:
+	$(NIX_BUILD) --no-out-link --attr landlockconfig.tests --attr llconfig.tests

--- a/pkg/nix/README.md
+++ b/pkg/nix/README.md
@@ -1,0 +1,55 @@
+# Nix package
+
+This directory includes a nix build script.
+
+## Building
+
+This will build the derivations and create symlinks `./llconfig` and
+`./landlockconfig` that point into the Nix store.
+
+```
+make
+```
+
+## Testing
+
+The `passthru.tests` attribute sets contain tests that can be run to validate
+the package. These are run in CI, and can be run locally:
+
+```
+make test
+```
+
+## Installing
+
+If you use flakes, you can import the package as a non-flake input:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    landlockconfig = {
+      url = "github:landlock-lsm/landlockconfig";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, landlockconfig }: let
+      # ...
+      pkgs = nixpkgs.legacyPackages.${system};
+      llcPkgs = import "${landlockconfig}/pkg/nix" { inherit pkgs; };
+      # llcPkgs.landlockconfig - the C library
+      # llcPkgs.llconfig - the command-line tool
+    in
+    # ...
+}
+```
+
+Otherwise, you can clone this repository and run one of the following:
+
+```
+$ nix-env --file ./pkg/nix --install --attr llconfig
+$
+$ # If you use `nix profile`, run this instead
+$ nix profile add --file ./pkg/nix llconfig
+```

--- a/pkg/nix/composition.nix
+++ b/pkg/nix/composition.nix
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+{
+  lib,
+  buildFHSEnv,
+  llconfig,
+  pkgsStatic,
+  runCommand,
+}:
+let
+  fhs = buildFHSEnv {
+    name = "landlockconfig-test-composition-fhs";
+    targetPkgs = _: [ llconfig ];
+    runScript = "llconfig run \"$@\" --debug true";
+    extraBuildCommands = ''
+      mkdir -p $out/var/tmp
+      rm -f $out/usr/bin/true
+      cp ${pkgsStatic.busybox}/bin/busybox $out/usr/bin/true
+    '';
+  };
+in
+runCommand "landlockconfig-test-composition" { } ''
+  set -euo pipefail
+
+  composition="${../../tests/composition}"
+  cp -r "$composition" ./composition
+  chmod -R u+w ./composition
+
+  check() {
+    diff -u "$composition/golden-debug.txt" <(${lib.getExe fhs} "$@" 2>&1)
+  }
+
+  check --toml composition/source/s1.toml --toml composition/source/s2.toml
+  check --toml composition/s.toml
+  check --json composition/s.json
+  check --toml composition/source/
+  check --json composition/source/s1.json --toml composition/source/s2.toml
+
+  touch $out
+''

--- a/pkg/nix/default.nix
+++ b/pkg/nix/default.nix
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+{
+  pkgs ? import <nixpkgs> { },
+}:
+{
+  landlockconfig = pkgs.callPackage ./landlockconfig.nix { };
+  llconfig = pkgs.callPackage ./llconfig.nix { };
+}

--- a/pkg/nix/landlockconfig.nix
+++ b/pkg/nix/landlockconfig.nix
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+{
+  lib,
+  cargo-c,
+  validatePkgConfig,
+  buildPackages,
+  stdenv,
+  testers,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "landlockconfig";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../..;
+    fileset = lib.fileset.difference (lib.fileset.gitTracked ../..) ../../pkg;
+  };
+
+  cargoLock.lockFile = ../../Cargo.lock;
+
+  nativeBuildInputs = [
+    cargo-c
+    validatePkgConfig
+  ];
+
+  postInstall = ''
+    cbuildFlags=(
+      --release
+      --frozen
+      --package landlockconfig_ffi
+      --prefix $out
+      --target ${stdenv.hostPlatform.rust.rustcTarget}
+    )
+
+    ${buildPackages.rust.envVars.setEnv} cargo cbuild "''${cbuildFlags[@]}"
+    ${buildPackages.rust.envVars.setEnv} cargo cinstall "''${cbuildFlags[@]}"
+  '';
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
+
+  meta = {
+    description = "Landlock configuration library";
+    homepage = "https://landlock.io/";
+    license = lib.licenses.OR [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    pkgConfigModules = [ "landlockconfig" ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkg/nix/llconfig.nix
+++ b/pkg/nix/llconfig.nix
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+{
+  lib,
+  rustPlatform,
+  versionCheckHook,
+}:
+let
+  gitInfo = builtins.fetchGit ../..;
+
+  # git log --max-count=1 --format=%cs
+  GIT_DATE =
+    let
+      year = builtins.substring 0 4 gitInfo.lastModifiedDate;
+      month = builtins.substring 4 2 gitInfo.lastModifiedDate;
+      day = builtins.substring 6 2 gitInfo.lastModifiedDate;
+    in
+    "${year}-${month}-${day}";
+
+  # git describe --always --abbrev=12 --exclude=* --dirty
+  GIT_COMMIT =
+    if gitInfo ? dirtyRev then
+      builtins.substring 0 12 gitInfo.dirtyRev + "-dirty"
+    else
+      builtins.substring 0 12 gitInfo.rev;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "llconfig";
+  version = "0.0.0";
+
+  src = lib.fileset.toSource {
+    root = ../..;
+    fileset = lib.fileset.difference (lib.fileset.gitTracked ../..) ../../pkg;
+  };
+
+  cargoLock.lockFile = ../../Cargo.lock;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  cargoBuildFlags = [
+    "--package=llconfig"
+  ];
+
+  env = { inherit GIT_COMMIT GIT_DATE; };
+
+  passthru.tests = { };
+
+  meta = {
+    description = "Command-line tool for the Landlock Config format";
+    homepage = "https://landlock.io/";
+    license = lib.licenses.OR [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    mainProgram = "llconfig";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkg/nix/llconfig.nix
+++ b/pkg/nix/llconfig.nix
@@ -3,6 +3,7 @@
   lib,
   rustPlatform,
   versionCheckHook,
+  callPackage,
 }:
 let
   gitInfo = builtins.fetchGit ../..;
@@ -43,7 +44,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = { inherit GIT_COMMIT GIT_DATE; };
 
-  passthru.tests = { };
+  passthru.tests.composition = callPackage ./composition.nix {
+    llconfig = finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Command-line tool for the Landlock Config format";


### PR DESCRIPTION
This adds a Nix script which builds a multi-output Nix derivation.

```
$ nix-build pkg/nix/landlockconfig.nix -A out -A lib -A dev
/nix/store/25jlmak28nc8adcx0if8w55fwnnygiy3-landlockconfig-0.1.0
/nix/store/qsdi8y97y65xprrmd9hxhvm7ddmgr1q6-landlockconfig-0.1.0-lib
/nix/store/hj3pngkh8w9p97g3mv5mqfkbg20gjwqc-landlockconfig-0.1.0-dev
$ tree result*
result
└── bin
    └── llconfig
result-dev
├── include
│   └── landlockconfig.h
├── lib
│   └── pkgconfig
│       └── landlockconfig.pc
└── nix-support
    └── propagated-build-inputs
result-lib
└── lib
    ├── liblandlockconfig.a
    ├── liblandlockconfig.so -> liblandlockconfig.so.0.1.0
    ├── liblandlockconfig.so.0.1 -> liblandlockconfig.so.0.1.0
    └── liblandlockconfig.so.0.1.0
```

It will also run the unit tests after compilation, and perform some simple pkg-config checks at installation time.
I also wrote two Nix tests: one that performs additional pkg-config tests, and another that performs the `composition` test (this required some additional work since it references full paths).
These can be run with:

```
$ nix-build pkg/nix/landlockconfig.nix -A tests --no-out-link
/nix/store/srwnfldwi55j8j75nj6211j7w3j33syn-landlockconfig-test-composition
/nix/store/6w2a5g6w380dsr7jn200gkgk3mqd4p72-check-pkg-config-landlockconfig
```

Finally, I added to the GitHub workflow to build and run the Nix derivation on push and pull request.
I didn't setup caching though; that can be done with the [nix-community/cache-nix-action](https://github.com/nix-community/cache-nix-action) (which I haven't used) or a free [cachix](https://cachix.org) cache with [cachix/cachix-action](https://github.com/cachix/cachix-action) (which I use [personally](https://github.com/Skyb0rg007/packages/blob/1f4b7048c076a3809527b6cc65f458ce22bbfa3d/.github/workflows/build-nix.yml#L23), but you need to setup the API keys).

Depends on #70