### PR TITLE
llconfig: Print the configuration schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
         diff -u "tests/composition/golden-debug.txt" \
           <(rustup run stable cargo run --locked --quiet --package llconfig -- run --json tests/composition/source/s1.json --toml tests/composition/source/s2.toml --debug true 2>&1)
 
+    - name: Check the llconfig schema command matches the reference schema
+      run: diff -u <(jq . ./schema/landlockconfig.json) <(rustup run stable cargo run --locked --quiet --package llconfig -- schema)
+
     - name: Check format
       run: rustup run stable cargo fmt --all -- --check
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ llconfig run --json examples/mini-write-tmp.json sh
 We can compose configurations by specifying `--json` or `--toml` (and related
 file paths) several times.
 
+To retrieve the JSON schema for Landlock configurations:
+```sh
+llconfig schema
+```
+
 ## TOML configuration example
 
 Here is an example of a [TOML configuration](examples/micro-var.toml) that uses

--- a/llconfig/src/main.rs
+++ b/llconfig/src/main.rs
@@ -65,6 +65,14 @@ enum Commands {
         )]
         command: Vec<String>,
     },
+
+    #[command(
+        about = "Print the JSON schema for Landlock configurations",
+        long_about = "Output the versioned JSON schema that describes the structure and \
+            validation rules for Landlock configuration files. The schema is printed to \
+            stdout in JSON format."
+    )]
+    Schema,
 }
 
 fn run(
@@ -137,6 +145,16 @@ fn run(
     Err(Command::new(name).args(command).exec().into())
 }
 
+fn schema() {
+    print!(
+        "{}",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../schema/landlockconfig.json"
+        ))
+    );
+}
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -147,5 +165,9 @@ fn main() -> anyhow::Result<()> {
             debug,
             command,
         } => run(json, toml, debug, command),
+        Commands::Schema => {
+            schema();
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Authoring or validating a configuration requires the JSON schema, which otherwise lives only in the source tree and is awkward to reach from an installed binary.

Expose it through a 'schema' subcommand that writes the schema to standard output, ready to pipe into a validator or save to a file. The schema is the versioned one kept as the single source of truth, embedded at build time so the installed binary carries it.

Print the schema:

`llconfig schema`